### PR TITLE
python3: urllib expects POST data to be bytes, not str

### DIFF
--- a/ns1/rest/transport/basic.py
+++ b/ns1/rest/transport/basic.py
@@ -48,6 +48,8 @@ class BasicTransport(TransportBase):
         else:
             opener = build_opener(HTTPSHandler)
 
+        if sys.version_info.major >= 3 and isinstance(data, str):
+            data = data.encode('utf-8')
         request = Request(url, headers=headers, data=data)
         request.get_method = lambda: method
 


### PR DESCRIPTION
This fixes the following error:

    Traceback (most recent call last):
      File ".../ansible_module_ns1_record.py", line 388, in <module>
        main()
      File ".../ansible_module_ns1_record.py", line 358, in main
        update(zone, record, module)
      File ".../ansible_module_ns1_record.py", line 294, in update
        record = record.update(errback=errback_generator(module),**args)
      File ".../python3.6/site-packages/ns1/records.py", line 109, in update
        callback=success, errback=errback, **kwargs)
      File ".../python3.6/site-packages/ns1/rest/records.py", line 136, in update
        errback=errback)
      File ".../python3.6/site-packages/ns1/rest/resource.py", line 73, in _make_request
        return self._transport.send(type, self._make_url(path), **kwargs)
      File ".../python3.6/site-packages/ns1/rest/transport/basic.py", line 80, in send
        resp = opener.open(request, timeout=self._timeout)
      File ".../python3.6/urllib/request.py", line 524, in open
        req = meth(req)
      File ".../python3.6/urllib/request.py", line 1248, in do_request_
        raise TypeError(msg)
    TypeError: POST data should be bytes, an iterable of bytes, or a file object. It cannot be of type str.

And I believe it is related to ns1/nsone-python#34 (but this is the basic transport)