### PR TITLE
Don't swallow unexpected exceptions in basic transport

### DIFF
--- a/ns1/rest/transport/basic.py
+++ b/ns1/rest/transport/basic.py
@@ -82,8 +82,8 @@ class BasicTransport(TransportBase):
         except HTTPError as e:
             resp = e
             body = resp.read()
-        if resp.code != 200:
-            handleProblem(resp.code, resp, body)
+            if not 200 <= resp.code < 300:
+                handleProblem(resp.code, resp, body)
 
         # TODO make sure json is valid
         try:

--- a/ns1/rest/transport/basic.py
+++ b/ns1/rest/transport/basic.py
@@ -82,12 +82,8 @@ class BasicTransport(TransportBase):
         except HTTPError as e:
             resp = e
             body = resp.read()
-        except Exception as e:
-            body = '"Service Unavailable"'
-            resp = HTTPError(url, 503, body, headers, None)
-        finally:
-            if resp.code != 200:
-                handleProblem(resp.code, resp, body)
+        if resp.code != 200:
+            handleProblem(resp.code, resp, body)
 
         # TODO make sure json is valid
         try:


### PR DESCRIPTION
The twisted transport is required to handle exceptions with a callback, but
baseic is just urllib and we can expose decent errors to users.