### PR TITLE
RE-211 - Update IPAM

### DIFF
--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -299,25 +299,14 @@ class NS1:
         address = ns1.ipam.Address(self.config, prefix=prefix, type=type, network=network)
         return address.create(callback=callback, errback=errback, **kwargs)
 
-    def loadScopeGroupbyID(self, id, callback=None, errback=None):
+    def loadScopeGroup(self, id, callback=None, errback=None):
         """
-        Load an existing Scope Group by ID into a high level Scope Group object
+        Load an existing Scope Group into a high level Scope Group object
 
         :param int id: id of an existing ScopeGroup
         """
         import ns1.ipam
         scope_group = ns1.ipam.Scopegroup(self.config, id=id)
-        return scope_group.load(callback=callback, errback=errback)
-
-    def loadScopeGroupbyName(self, name, service_group_id, callback=None, errback=None):
-        """
-        Load an existing Scope Group by name and service group id into a high level Scope Group object
-
-        :param str name: Name of an existing Scope Group
-        :param int service_group_id: id of the service group the Scope group is associated with
-        """
-        import ns1.ipam
-        scope_group = ns1.ipam.Scopegroup(self.config, name=name, service_group_id=service_group_id)
         return scope_group.load(callback=callback, errback=errback)
 
     def createScopeGroup(self, name, service_group_id, dhcp4, dhcp6, callback=None, errback=None):
@@ -333,6 +322,26 @@ class NS1:
         import ns1.ipam
         scope_group = ns1.ipam.Scopegroup(self.config, name=name, service_group_id=service_group_id)
         return scope_group.create(dhcp4=dhcp4, dhcp6=dhcp6, callback=callback, errback=errback)
+
+    def createReservation(self, scopegroup_id, address_id, mac, callback=None, errback=None):
+        import ns1.ipam
+        reservation = ns1.ipam.Reservation(self.config, scopegroup_id, address_id, mac)
+        return reservation.create(callback=callback, errback=errback)
+
+    def loadReservation(self, scopegroup_id, address_id, callback=None, errback=None):
+        import ns1.ipam
+        reservation = ns1.ipam.Reservation(self.config, scopegroup_id, address_id)
+        return reservation.load(callback=callback, errback=errback)
+
+    def createScope(self, scopegroup_id, address_id, callback=None, errback=None):
+        import ns1.ipam
+        scope = ns1.ipam.Scope(self.config, scopegroup_id, address_id)
+        return scope.create(callback=callback, errback=errback)
+
+    def loadScope(self, scopegroup_id, address_id, callback=None, errback=None):
+        import ns1.ipam
+        scope = ns1.ipam.Scope(self.config, scopegroup_id, address_id)
+        return scope.load(callback=callback, errback=errback)
 
     def generateDHCPOptionsTemplate(self, address_family):
         """

--- a/ns1/rest/ipam.py
+++ b/ns1/rest/ipam.py
@@ -69,22 +69,21 @@ class Addresses(resource.BaseResource):
                                   errback=errback)
 
     def retrieve_dhcp_option(self, address_id, callback=None, errback=None):
-        params = {'address_id': address_id}
         return self._make_request('GET', '%s/%s/options' % (self.ROOT, address_id),
-                                  params=params,
                                   callback=callback,
                                   errback=errback)
 
-    def create_dhcp_option(self, address_id, dhcp_option, callback=None, errback=None):
-        body = {"dhcp_option": dhcp_option}
+    def create_dhcp_option(self, address_id, option_name, option_value, callback=None, errback=None):
+        body = {"name": option_name,
+                "value": option_value}
         return self._make_request('POST',
                                   '%s/%s/options' % (self.ROOT, address_id),
                                   body=body,
                                   callback=callback,
                                   errback=errback)
 
-    def delete_dhcp_option(self, address_id, callback=None, errback=None):
-        params = {'address_id': address_id}
+    def delete_dhcp_option(self, address_id, option_name, callback=None, errback=None):
+        params = {"name": option_name}
         return self._make_request('DELETE', '%s/%s/options' % (self.ROOT, address_id),
                                   params=params,
                                   callback=callback,

--- a/ns1/rest/ipam.py
+++ b/ns1/rest/ipam.py
@@ -10,7 +10,7 @@ from . import resource
 class Addresses(resource.BaseResource):
     ROOT = 'ipam/address'
     INT_FIELDS = ['network_id', 'address_id', 'root_address_id', ' merged_address_id', 'scope_group_id']
-    PASSTHRU_FIELDS = ['prefix', 'type', 'desc', 'kvps', 'tags', 'reserve', 'dhcp_options']
+    PASSTHRU_FIELDS = ['prefix', 'type', 'desc', 'kvps', 'tags', 'reserve', 'dhcp_option']
     BOOL_FIELDS = ['parent']
 
     def _buildBody(self, **kwargs):
@@ -67,6 +67,29 @@ class Addresses(resource.BaseResource):
         return self._make_request('GET', '%s/%s/report' % (self.ROOT, address_id),
                                   callback=callback,
                                   errback=errback)
+
+    def retrieve_dhcp_option(self, address_id, callback=None, errback=None):
+        params = {'address_id': address_id}
+        return self._make_request('GET', '%s/%s/options' % (self.ROOT, address_id),
+                                  params=params,
+                                  callback=callback,
+                                  errback=errback)
+
+    def create_dhcp_option(self, address_id, dhcp_option, callback=None, errback=None):
+        body = {"dhcp_option": dhcp_option}
+        return self._make_request('POST',
+                                  '%s/%s/options' % (self.ROOT, address_id),
+                                  body=body,
+                                  callback=callback,
+                                  errback=errback)
+
+    def delete_dhcp_option(self, address_id, callback=None, errback=None):
+        params = {'address_id': address_id}
+        return self._make_request('DELETE', '%s/%s/options' % (self.ROOT, address_id),
+                                  params=params,
+                                  callback=callback,
+                                  errback=errback)
+
 
     # NYI in API
     # def retrieve_next(self, address_id, callback=None, errback=None):
@@ -170,7 +193,7 @@ class Networks(resource.BaseResource):
 
 
 class Scopegroups(resource.BaseResource):
-    ROOT = 'ipam/scope_group'
+    ROOT = 'dhcp/scopegroup'
     INT_FIELDS = ['scope_group_id', 'valid_lifetime_secs', 'renew_timer_secs', 'rebind_timer_secs', 'service_group_id']
     PASSTHRU_FIELDS = ['dhcp_option', 'dhcpv4', 'dhcpv6', 'name']
     BOOL_FIELDS = ['enabled', 'echo_client_id']
@@ -210,3 +233,80 @@ class Scopegroups(resource.BaseResource):
         return self._make_request('GET', '%s/%s' % (self.ROOT, scope_group_id),
                                   callback=callback,
                                   errback=errback)
+
+
+class Scopes(resource.BaseResource):
+    ROOT = 'dhcp/scopegroup'
+
+    def create(self, scope_group_id, address_id, callback=None, errback=None):
+        body = {"address_id": address_id}
+        return self._make_request('POST', '%s/%s/scopes' % (self.ROOT, scope_group_id),
+                                  body=body,
+                                  callback=callback,
+                                  errback=errback)
+
+    def list(self, scope_group_id, callback=None, errback=None):
+        return self._make_request('GET', '%s/%s/scopes' % (self.ROOT, scope_group_id),
+                                  callback=callback,
+                                  errback=errback)
+
+    def delete(self, scope_group_id, address_id, callback=None, errback=None):
+        params = {'address_id': address_id}
+        return self._make_request('DELETE', '%s/%s/scopes' % (self.ROOT, scope_group_id),
+                                  params=params,
+                                  callback=callback,
+                                  errback=errback)
+
+
+class Reservations(resource.BaseResource):
+    ROOT = 'dhcp/scopegroup'
+    INT_FIELDS = ['scopegroup_id', 'address_id']
+    PASSTHRU_FIELDS = ['mac']
+    BOOL_FIELDS = []
+
+    def _buildBody(self, **kwargs):
+        body = {}
+        self._buildStdBody(body, kwargs)
+        return body
+
+    @classmethod
+    def select_from_list(cls, result, address_id):
+        for item in result:
+            if item.get('address_id') == int(address_id):
+                return item
+        return None
+
+    def create(self, scopegroup_id, address_id, callback=None, errback=None, **kwargs):
+        kwargs['address_id'] = address_id
+        body = self._buildBody(**kwargs)
+
+        def success(result, *args):
+            return self.retrieve(scopegroup_id, address_id, callback=callback, errback=errback)
+
+        reservation = self._make_request('POST',
+                                         '%s/%s/reservations' % (self.ROOT, scopegroup_id),
+                                         body=body,
+                                         callback=success,
+                                         errback=errback)
+        return reservation
+
+    def delete(self, scopegroup_id, address_id, callback=None, errback=None):
+        return self._make_request('DELETE',
+                                  '%s/%s/reservations?address_id=%s' % (self.ROOT, scopegroup_id, address_id),
+                                  callback=callback,
+                                  errback=errback)
+
+    def list(self, scopegroup_id, callback=None, errback=None):
+        return self._make_request('GET',
+                                  '%s/%s/reservations' % (self.ROOT, scopegroup_id),
+                                  callback=callback,
+                                  errback=errback)
+
+    def retrieve(self, scopegroup_id, address_id, callback=None, errback=None):
+        result = self.list(scopegroup_id, errback=errback)
+        reservation = Reservations.select_from_list(result, address_id)
+
+        if callback is not None:
+            return callback(reservation)
+        else:
+            return reservation

--- a/ns1/rest/ipam.py
+++ b/ns1/rest/ipam.py
@@ -237,24 +237,44 @@ class Scopegroups(resource.BaseResource):
 class Scopes(resource.BaseResource):
     ROOT = 'dhcp/scopegroup'
 
-    def create(self, scope_group_id, address_id, callback=None, errback=None):
+    @classmethod
+    def select_from_list(cls, result, address_id):
+        for item in result:
+            if item.get('address_id') == int(address_id):
+                return item
+        return None
+
+    def create(self, scopegroup_id, address_id, callback=None, errback=None):
         body = {"address_id": address_id}
-        return self._make_request('POST', '%s/%s/scopes' % (self.ROOT, scope_group_id),
+
+        def success(result, *args):
+            return self.retrieve(scopegroup_id, address_id, callback=callback, errback=errback)
+
+        return self._make_request('POST', '%s/%s/scopes' % (self.ROOT, scopegroup_id),
                                   body=body,
+                                  callback=success,
+                                  errback=errback)
+
+    def list(self, scopegroup_id, callback=None, errback=None):
+        return self._make_request('GET', '%s/%s/scopes' % (self.ROOT, scopegroup_id),
                                   callback=callback,
                                   errback=errback)
 
-    def list(self, scope_group_id, callback=None, errback=None):
-        return self._make_request('GET', '%s/%s/scopes' % (self.ROOT, scope_group_id),
-                                  callback=callback,
-                                  errback=errback)
-
-    def delete(self, scope_group_id, address_id, callback=None, errback=None):
+    def delete(self, scopegroup_id, address_id, callback=None, errback=None):
         params = {'address_id': address_id}
-        return self._make_request('DELETE', '%s/%s/scopes' % (self.ROOT, scope_group_id),
+        return self._make_request('DELETE', '%s/%s/scopes' % (self.ROOT, scopegroup_id),
                                   params=params,
                                   callback=callback,
                                   errback=errback)
+
+    def retrieve(self, scopegroup_id, address_id, callback=None, errback=None):
+        result = self.list(scopegroup_id, errback=errback)
+        scope = Scopes.select_from_list(result, address_id)
+
+        if callback is not None:
+            return callback(scope)
+        else:
+            return scope
 
 
 class Reservations(resource.BaseResource):

--- a/ns1/rest/transport/basic.py
+++ b/ns1/rest/transport/basic.py
@@ -26,7 +26,7 @@ class BasicTransport(TransportBase):
         TransportBase.__init__(self, config, self.__module__)
         self._timeout = self._config.get('timeout', socket._GLOBAL_DEFAULT_TIMEOUT)
 
-    def send(self, method, url, headers=None, data=None, files=None,
+    def send(self, method, url, headers=None, data=None, files=None, params=None,
              callback=None, errback=None):
         if headers is None:
             headers = {}
@@ -87,17 +87,21 @@ class BasicTransport(TransportBase):
             if not 200 <= resp.code < 300:
                 handleProblem(resp.code, resp, body)
 
-        # TODO make sure json is valid
-        try:
-            jsonOut = json.loads(body)
-        except ValueError:
-            if errback:
-                errback(resp)
-                return
-            else:
-                raise ResourceException('invalid json in response',
-                                        resp,
-                                        body)
+        # TODO make sure json is valid if there is a body
+        if body:
+            try:
+                jsonOut = json.loads(body)
+            except ValueError:
+                if errback:
+                    errback(resp)
+                    return
+                else:
+                    raise ResourceException('invalid json in response',
+                                            resp,
+                                            body)
+        else:
+            jsonOut = None
+
         if callback:
             return callback(jsonOut)
         else:

--- a/ns1/rest/transport/twisted.py
+++ b/ns1/rest/transport/twisted.py
@@ -110,7 +110,7 @@ class TwistedTransport(TransportBase):
                                          response.request.absoluteURI,
                                          response.code,
                                          data))
-        if response.code != 200:
+        if response.code < 200 or response.code >= 300:
             if response.code == 429:
                 raise RateLimitException(
                     'rate limit exceeded', response, body,
@@ -125,12 +125,16 @@ class TwistedTransport(TransportBase):
                                     body)
             else:
                 raise ResourceException('server error', response, body)
-        try:
-            jsonOut = json.loads(body)
-        except:
-            raise ResourceException('invalid json in response',
-                                    response,
-                                    body)
+
+        if body:
+            try:
+                jsonOut = json.loads(body)
+            except:
+                raise ResourceException('invalid json in response',
+                                        response,
+                                        body)
+        else:
+            jsonOut = None
         if user_callback:
             # set these in case callback throws, so we have them for errback
             self.response = response

--- a/tests/unit/test_address.py
+++ b/tests/unit/test_address.py
@@ -97,3 +97,46 @@ def test_rest_address_delete(address_config, address_id, url):
                                             url,
                                             callback=None,
                                             errback=None)
+
+
+@pytest.mark.parametrize('address_id, option_name, option_value, url',
+                         [('1', 'dhcpv4/test', 'test',
+                           'ipam/address/1/options')])
+def test_rest_address_create_option(address_config, address_id, option_name,
+                                    option_value, url):
+    z = ns1.rest.ipam.Addresses(address_config)
+    z._make_request = mock.MagicMock()
+    z.create_dhcp_option(address_id, option_name, option_value)
+    z._make_request.assert_called_once_with('POST',
+                                            url,
+                                            callback=None,
+                                            errback=None,
+                                            body={"name": option_name,
+                                                  "value": option_value})
+
+
+@pytest.mark.parametrize('address_id, url',
+                         [('1', 'ipam/address/1/options')])
+def test_rest_address_retrieve_option(address_config, address_id, url):
+    z = ns1.rest.ipam.Addresses(address_config)
+    z._make_request = mock.MagicMock()
+    z.retrieve_dhcp_option(address_id)
+    z._make_request.assert_called_once_with('GET',
+                                            url,
+                                            callback=None,
+                                            errback=None)
+
+
+@pytest.mark.parametrize('address_id, option_name, url',
+                         [('1', 'dhcpv4/test',
+                           'ipam/address/1/options')])
+def test_rest_address_delete_option(address_config, address_id, option_name,
+                                    url):
+    z = ns1.rest.ipam.Addresses(address_config)
+    z._make_request = mock.MagicMock()
+    z.delete_dhcp_option(address_id, option_name)
+    z._make_request.assert_called_once_with('DELETE',
+                                            url,
+                                            params={"name": option_name},
+                                            callback=None,
+                                            errback=None)

--- a/tests/unit/test_reservation.py
+++ b/tests/unit/test_reservation.py
@@ -1,0 +1,86 @@
+import pytest
+
+import ns1.rest.ipam
+
+try:  # Python 3.3 +
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+
+def Any():
+    class Any():
+        def __eq__(self, other):
+            return True
+    return Any()
+
+
+@pytest.fixture
+def reservation_config(config):
+    config.loadFromDict({
+        'endpoint': 'api.nsone.net',
+        'default_key': 'test1',
+        'keys': {
+            'test1': {
+                'key': 'key-1',
+                'desc': 'test key number 1',
+                'writeLock': True
+            }
+        }
+    })
+    return config
+
+
+def test_rest_reservation_list(reservation_config):
+    z = ns1.rest.ipam.Reservations(reservation_config)
+    z._make_request = mock.MagicMock()
+    z.list(1)
+    z._make_request.assert_called_once_with('GET',
+                                            'dhcp/scopegroup/1/reservations',
+                                            callback=None,
+                                            errback=None)
+
+
+@pytest.mark.parametrize('scopegroup_id, address_id, url',
+                         [(1, 2,
+                           'dhcp/scopegroup/1/reservations')])
+def test_rest_reservation_retrieve(reservation_config, scopegroup_id,
+                                   address_id, url):
+    z = ns1.rest.ipam.Reservations(reservation_config)
+    z._make_request = mock.MagicMock()
+    z.retrieve(scopegroup_id, address_id)
+    z._make_request.assert_called_once_with('GET',
+                                            url,
+                                            callback=None,
+                                            errback=None)
+
+
+@pytest.mark.parametrize('scopegroup_id, address_id, mac, url',
+                         [(1, 2, '12:34:56:78:90:ab',
+                           'dhcp/scopegroup/1/reservations')])
+def test_rest_reservation_create(reservation_config, scopegroup_id,
+                                 address_id, mac, url):
+    z = ns1.rest.ipam.Reservations(reservation_config)
+    z._make_request = mock.MagicMock()
+
+    z.create(scopegroup_id, address_id, mac=mac)
+    z._make_request.assert_called_once_with('POST',
+                                            url,
+                                            callback=Any(),
+                                            errback=None,
+                                            body={"address_id": address_id,
+                                                  "mac": mac})
+
+
+@pytest.mark.parametrize('scopegroup_id, address_id, url',
+                         [(1, 2,
+                           'dhcp/scopegroup/1/reservations?address_id=2')])
+def test_rest_reservation_delete(reservation_config, scopegroup_id,
+                                 address_id, url):
+    z = ns1.rest.ipam.Reservations(reservation_config)
+    z._make_request = mock.MagicMock()
+    z.delete(scopegroup_id, address_id)
+    z._make_request.assert_called_once_with('DELETE',
+                                            url,
+                                            callback=None,
+                                            errback=None)

--- a/tests/unit/test_scope.py
+++ b/tests/unit/test_scope.py
@@ -1,0 +1,72 @@
+import pytest
+
+import ns1.rest.ipam
+
+try:  # Python 3.3 +
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+
+def Any():
+    class Any():
+        def __eq__(self, other):
+            return True
+    return Any()
+
+
+@pytest.fixture
+def scope_config(config):
+    config.loadFromDict({
+        'endpoint': 'api.nsone.net',
+        'default_key': 'test1',
+        'keys': {
+            'test1': {
+                'key': 'key-1',
+                'desc': 'test key number 1',
+                'writeLock': True
+            }
+        }
+    })
+    return config
+
+
+def test_rest_scope_list(scope_config):
+    z = ns1.rest.ipam.Scopes(scope_config)
+    z._make_request = mock.MagicMock()
+    z.list(1)
+    z._make_request.assert_called_once_with('GET',
+                                            'dhcp/scopegroup/1/scopes',
+                                            callback=None,
+                                            errback=None)
+
+
+@pytest.mark.parametrize('scopegroup_id, address_id, url',
+                         [(1, 2,
+                           'dhcp/scopegroup/1/scopes')])
+def test_rest_scope_create(scope_config, scopegroup_id,
+                           address_id, url):
+    z = ns1.rest.ipam.Scopes(scope_config)
+    z._make_request = mock.MagicMock()
+
+    z.create(scopegroup_id, address_id)
+    z._make_request.assert_called_once_with('POST',
+                                            url,
+                                            callback=Any(),
+                                            errback=None,
+                                            body={"address_id": address_id})
+
+
+@pytest.mark.parametrize('scopegroup_id, address_id, url',
+                         [(1, 2,
+                           'dhcp/scopegroup/1/scopes')])
+def test_rest_scope_delete(scope_config, scopegroup_id,
+                           address_id, url):
+    z = ns1.rest.ipam.Scopes(scope_config)
+    z._make_request = mock.MagicMock()
+    z.delete(scopegroup_id, address_id)
+    z._make_request.assert_called_once_with('DELETE',
+                                            url,
+                                            params={"address_id": address_id},
+                                            callback=None,
+                                            errback=None)

--- a/tests/unit/test_scope.py
+++ b/tests/unit/test_scope.py
@@ -44,6 +44,20 @@ def test_rest_scope_list(scope_config):
 @pytest.mark.parametrize('scopegroup_id, address_id, url',
                          [(1, 2,
                            'dhcp/scopegroup/1/scopes')])
+def test_rest_scope_retrieve(scope_config, scopegroup_id,
+                             address_id, url):
+    z = ns1.rest.ipam.Scopes(scope_config)
+    z._make_request = mock.MagicMock()
+    z.retrieve(scopegroup_id, address_id)
+    z._make_request.assert_called_once_with('GET',
+                                            url,
+                                            callback=None,
+                                            errback=None)
+
+
+@pytest.mark.parametrize('scopegroup_id, address_id, url',
+                         [(1, 2,
+                           'dhcp/scopegroup/1/scopes')])
 def test_rest_scope_create(scope_config, scopegroup_id,
                            address_id, url):
     z = ns1.rest.ipam.Scopes(scope_config)

--- a/tests/unit/test_scope_group.py
+++ b/tests/unit/test_scope_group.py
@@ -29,12 +29,12 @@ def test_rest_scope_group_list(scope_group_config):
     z._make_request = mock.MagicMock()
     z.list()
     z._make_request.assert_called_once_with('GET',
-                                            'ipam/scope_group',
+                                            'dhcp/scopegroup',
                                             callback=None,
                                             errback=None)
 
 
-@pytest.mark.parametrize('scope_group_id, url', [('1', 'ipam/scope_group/1')])
+@pytest.mark.parametrize('scope_group_id, url', [('1', 'dhcp/scopegroup/1')])
 def test_rest_scope_group_retrieve(scope_group_config, scope_group_id, url):
     z = ns1.rest.ipam.Scopegroups(scope_group_config)
     z._make_request = mock.MagicMock()
@@ -46,7 +46,7 @@ def test_rest_scope_group_retrieve(scope_group_config, scope_group_id, url):
 
 
 @pytest.mark.parametrize('scope_group_name, url',
-                         [('test_scope_group', 'ipam/scope_group')])
+                         [('test_scope_group', 'dhcp/scopegroup')])
 def test_rest_scope_group_create(scope_group_config, scope_group_name, url):
     z = ns1.rest.ipam.Scopegroups(scope_group_config)
     z._make_request = mock.MagicMock()
@@ -59,7 +59,7 @@ def test_rest_scope_group_create(scope_group_config, scope_group_name, url):
 
 
 @pytest.mark.parametrize('scope_group_id, scope_group_name, url',
-                         [('1', 'awesome scope_group', 'ipam/scope_group/1')])
+                         [('1', 'awesome scope_group', 'dhcp/scopegroup/1')])
 def test_rest_scope_group_update(scope_group_config,
                                  scope_group_id, scope_group_name, url):
     z = ns1.rest.ipam.Scopegroups(scope_group_config)
@@ -72,7 +72,7 @@ def test_rest_scope_group_update(scope_group_config,
                                             body={"name": scope_group_name})
 
 
-@pytest.mark.parametrize('scope_group_id, url', [('1', 'ipam/scope_group/1')])
+@pytest.mark.parametrize('scope_group_id, url', [('1', 'dhcp/scopegroup/1')])
 def test_rest_scope_group_delete(scope_group_config, scope_group_id, url):
     z = ns1.rest.ipam.Scopegroups(scope_group_config)
     z._make_request = mock.MagicMock()

--- a/tests/unit/test_scope_group.py
+++ b/tests/unit/test_scope_group.py
@@ -64,7 +64,7 @@ def test_rest_scope_group_update(scope_group_config,
                                  scope_group_id, scope_group_name, url):
     z = ns1.rest.ipam.Scopegroups(scope_group_config)
     z._make_request = mock.MagicMock()
-    z.update(1, name=scope_group_name)
+    z.update(scope_group_id, name=scope_group_name)
     z._make_request.assert_called_once_with('POST',
                                             url,
                                             callback=None,


### PR DESCRIPTION
Add Scopes, Scope, tests and top level helpers
Add Reservations, Reservation, tests and top level helpers
Add DHCP Option manipulators to Addresses (and tests)
Added create_scope, scopes, reserve and reservations to Scopegroups
Added reserve to Address
Use new API routes and update tests
Allow 204 responses for all transport options