### PR TITLE
Adds license_file metadata to include in sdist and wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+license_file = LICENSE
+
 [bdist_wheel]
 universal=1
 [aliases]


### PR DESCRIPTION
Per #31 LICENSE is not currently being included in source distributions.  Adding `license_file` to setuptools metadata should resolve this issue.