### PR TITLE
Fix support of 'use_client_subnet' option

### DIFF
--- a/ns1/rest/records.py
+++ b/ns1/rest/records.py
@@ -17,7 +17,7 @@ class Records(resource.BaseResource):
     ROOT = 'zones'
 
     INT_FIELDS = ['ttl']
-    BOOL_FIELDS = ['use_csubnet', 'override_ttl']
+    BOOL_FIELDS = ['use_client_subnet', 'use_csubnet', 'override_ttl']
     PASSTHRU_FIELDS = ['networks', 'meta', 'regions', 'link']
 
     # answers must be:


### PR DESCRIPTION
If you pass 'use_client_subnet=True', that is silently being ignored
since it is "unknown" parameter to the Records resource.
    
Fixes: 2a0a1d119e5e1e40222f6e58fbc83e01b4108891
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>