### PR TITLE
INT-46: ipam.Address.type is now ipam.Address.status

### DIFF
--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -290,31 +290,31 @@ class NS1:
         address = ns1.ipam.Address(self.config, id=id)
         return address.load(callback=callback, errback=errback)
 
-    def loadAddressbyPrefix(self, prefix, type, network_id, callback=None, errback=None):
+    def loadAddressbyPrefix(self, prefix, status, network_id, callback=None, errback=None):
         """
-        Load an existing address by prefix, type and network into a high level Address object
+        Load an existing address by prefix, status and network into a high level Address object
 
         :param str prefix: CIDR prefix of an existing Address
-        :param str type: Type of address assignement (planned, assignment or host)
+        :param str status: The status of address assignment (planned or assigned)
         :param int network_id: network_id associated with the address
         """
         import ns1.ipam
         network = ns1.ipam.Network(self.config, id=network_id).load()
-        address = ns1.ipam.Address(self.config, prefix=prefix, type=type, network=network)
+        address = ns1.ipam.Address(self.config, prefix=prefix, status=status, network=network)
         return address.load(callback=callback, errback=errback)
 
-    def createAddress(self, prefix, type, network_id, callback=None, errback=None, **kwargs):
+    def createAddress(self, prefix, status, network_id, callback=None, errback=None, **kwargs):
         """
         Create a new Address
         For the list of keywords available, see :attr:`ns1.rest.ipam.Addresses.INT_FIELDS` and :attr:`ns1.rest.ipam.Addresses.PASSTHRU_FIELDS`
 
         :param str prefix: CIDR prefix of the address to be created
-        :param str type: Type of address assignement (planned, assignment or host)
+        :param str status: The status of address assignment (planned or assigned)
         :param int network_id: network_id associated with the address
         """
         import ns1.ipam
         network = ns1.ipam.Network(self.config, id=network_id).load()
-        address = ns1.ipam.Address(self.config, prefix=prefix, type=type, network=network)
+        address = ns1.ipam.Address(self.config, prefix=prefix, status=status, network=network)
         return address.create(callback=callback, errback=errback, **kwargs)
 
     def loadScopeGroup(self, id, callback=None, errback=None):

--- a/ns1/rest/ipam.py
+++ b/ns1/rest/ipam.py
@@ -10,7 +10,7 @@ from . import resource
 class Addresses(resource.BaseResource):
     ROOT = 'ipam/address'
     INT_FIELDS = ['network_id', 'address_id', 'root_address_id', ' merged_address_id', 'scope_group_id']
-    PASSTHRU_FIELDS = ['prefix', 'type', 'desc', 'kvps', 'tags', 'reserve']
+    PASSTHRU_FIELDS = ['prefix', 'status', 'desc', 'kvps', 'tags', 'reserve']
     BOOL_FIELDS = ['parent']
 
     def _buildBody(self, **kwargs):

--- a/tests/unit/test_address.py
+++ b/tests/unit/test_address.py
@@ -56,13 +56,13 @@ def test_rest_address_report(address_config, address_id, url):
                                             errback=None)
 
 
-@pytest.mark.parametrize('prefix, network_id, address_type, url',
+@pytest.mark.parametrize('prefix, network_id, address_status, url',
                          [('192.168.0.0/24', 1, 'planned', 'ipam/address')])
 def test_rest_address_create(address_config,
-                             prefix, network_id, address_type, url):
+                             prefix, network_id, address_status, url):
     z = ns1.rest.ipam.Addresses(address_config)
     z._make_request = mock.MagicMock()
-    z.create(prefix=prefix, network_id=network_id, type=address_type)
+    z.create(prefix=prefix, network_id=network_id, status=address_status)
     z._make_request.assert_called_once_with('PUT',
                                             url,
                                             callback=None,
@@ -70,7 +70,7 @@ def test_rest_address_create(address_config,
                                             params={"parent": True},
                                             body={"network_id": network_id,
                                                   "prefix": prefix,
-                                                  "type": address_type
+                                                  "status": address_status
                                                   })
 
 


### PR DESCRIPTION
The "type" field of ipam.Address has been renamed to "status" in
the API as of v2.2. Additionally, the "assignment" value becomes
"assigned".

For those using IPAM functionality, there are some minor but
potentially breaking changes:

v2.1 users:
  * please continue to use v0.13.0 of the SDK

v2.2 users with existing code for IPAM:
  * NS1 class:
    * createAddress method: the "type" arg is now "status"
    * loadAddressByPrefix method: the "type" arg is now "status"
  * ipam.Address:
    * "type" kwarg to init is now "status"
    * "type" attr is now "status" attr
  * ipam.Network:
    * new_address method: "type" arg is now "status"
  * Valid values for "status" (née "type") have changed:
    * previously: ["planned", "assignment", "host"]
    * now:        ["planned", "assigned", "host"]