### PR TITLE
fix passing wrong args when deleting a reservation

### DIFF
--- a/ns1/ipam.py
+++ b/ns1/ipam.py
@@ -538,7 +538,7 @@ class Reservation(object):
         """
         Delete the Reservation
         """
-        return self._rest.delete(self.scopegroup_id, self.address_id, callback=callback, errback=errback)
+        return self._rest.delete(self.id, callback=callback, errback=errback)
 
     def create(self, callback=None, errback=None, **kwargs):
         """

--- a/tests/unit/test_ipam.py
+++ b/tests/unit/test_ipam.py
@@ -1,0 +1,81 @@
+import pytest
+
+import ns1.ipam
+
+try:  # Python 3.3 +
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+
+@pytest.fixture
+def reservation_config(config):
+    config.loadFromDict({
+        'endpoint': 'api.nsone.net',
+        'default_key': 'test1',
+        'keys': {
+            'test1': {
+                'key': 'key-1',
+                'desc': 'test key number 1',
+                'writeLock': True
+            }
+        }
+    })
+    return config
+
+
+def test_reservation_load(reservation_config):
+    z = ns1.ipam.Reservation(
+        reservation_config, 'scopegroup_id', 'address_id', 'reservation_id'
+    )
+    z._rest = mock.MagicMock()
+    z.load()
+
+    args, kwargs = z._rest.retrieve.call_args_list[0]
+    assert args == (z.id,)
+    assert len(kwargs) == 2
+    assert kwargs['callback'] is not None
+    assert kwargs['errback'] is None
+
+
+def test_reservation_create(reservation_config):
+    z = ns1.ipam.Reservation(
+        reservation_config, 'scopegroup_id', 'address_id', 'reservation_id'
+    )
+    z._rest = mock.MagicMock()
+    z.create()
+
+    args, kwargs = z._rest.create.call_args_list[0]
+    assert args == (z.scopegroup_id, z.address_id)
+    assert len(kwargs) == 4
+    assert kwargs['options'] == z.options
+    assert kwargs['mac'] == z.mac
+    assert kwargs['callback'] is not None
+    assert kwargs['errback'] is None
+
+
+def test_reservation_delete(reservation_config):
+    z = ns1.ipam.Reservation(
+        reservation_config, 'scopegroup_id', 'address_id', 'reservation_id'
+    )
+    z._rest = mock.MagicMock()
+    z.delete()
+
+    assert z.id == 'reservation_id'
+    z._rest.delete.assert_called_once_with(z.id, callback=None, errback=None)
+
+
+def test_reservation_update(reservation_config):
+    z = ns1.ipam.Reservation(
+        reservation_config, 'scopegroup_id', 'address_id', 'reservation_id'
+    )
+    z._rest = mock.MagicMock()
+    z.data = 'my_data'
+    z.update('my_options')
+
+    args, kwargs = z._rest.update.call_args_list[0]
+    assert args == (z.id, 'my_options')
+    assert len(kwargs) == 3
+    assert kwargs['callback'] is not None
+    assert kwargs['errback'] is None
+    assert kwargs['parent'] is True


### PR DESCRIPTION
rest.delete expects reservation_id (self.id), was being passed
scopegroup_id and address_id.

also added some basic passthru tests for ipam.Reservations