### PR TITLE
INT-131: support monitoring regions and jobtypes endpoint

### DIFF
--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -173,6 +173,26 @@ class NS1:
 
         return ns1.rest.monitoring.NotifyLists(self.config)
 
+    def monitoring_jobtypes(self):
+        """
+        Return a new raw REST interface to notify list resources
+
+        :rtype: :py:class:`ns1.rest.monitoring.NotifyLists`
+        """
+        import ns1.rest.monitoring
+
+        return ns1.rest.monitoring.JobTypes(self.config)
+
+    def monitoring_regions(self):
+        """
+        Return a new raw REST interface to notify list resources
+
+        :rtype: :py:class:`ns1.rest.monitoring.NotifyLists`
+        """
+        import ns1.rest.monitoring
+
+        return ns1.rest.monitoring.Regions(self.config)
+
     def plan(self):
         """
         Return a new raw REST interface to account plan

--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -175,9 +175,9 @@ class NS1:
 
     def monitoring_jobtypes(self):
         """
-        Return a new raw REST interface to notify list resources
+        Return a new raw REST interface to monitoring jobtypes resources
 
-        :rtype: :py:class:`ns1.rest.monitoring.NotifyLists`
+        :rtype: :py:class:`ns1.rest.monitoring.JobTypes`
         """
         import ns1.rest.monitoring
 
@@ -185,9 +185,9 @@ class NS1:
 
     def monitoring_regions(self):
         """
-        Return a new raw REST interface to notify list resources
+        Return a new raw REST interface to monitoring regions resources
 
-        :rtype: :py:class:`ns1.rest.monitoring.NotifyLists`
+        :rtype: :py:class:`ns1.rest.monitoring.Regions`
         """
         import ns1.rest.monitoring
 

--- a/ns1/rest/monitoring.py
+++ b/ns1/rest/monitoring.py
@@ -67,18 +67,6 @@ class Monitors(resource.BaseResource):
             errback=errback,
         )
 
-    @property
-    def jobtypes(self, callback=None, errback=None):
-        return self._make_request(
-            "GET", "monitoring/jobtypes", callback=callback, errback=errback,
-        )
-
-    @property
-    def regions(self, callback=None, errback=None):
-        return self._make_request(
-            "GET", "monitoring/regions", callback=callback, errback=errback,
-        )
-
 
 class NotifyLists(resource.BaseResource):
 
@@ -124,4 +112,26 @@ class NotifyLists(resource.BaseResource):
             "%s/%s" % (self.ROOT, nlid),
             callback=callback,
             errback=errback,
+        )
+
+
+class JobTypes(resource.BaseResource):
+
+    ROOT = "monitoring/jobtypes"
+    PASSTHRU_FIELDS = []
+
+    def list(self, callback=None, errback=None):
+        return self._make_request(
+            "GET", self.ROOT, callback=callback, errback=errback,
+        )
+
+
+class Regions(resource.BaseResource):
+
+    ROOT = "monitoring/regions"
+    PASSTHRU_FIELDS = []
+
+    def list(self, callback=None, errback=None):
+        return self._make_request(
+            "GET", self.ROOT, callback=callback, errback=errback,
         )

--- a/ns1/rest/monitoring.py
+++ b/ns1/rest/monitoring.py
@@ -67,6 +67,18 @@ class Monitors(resource.BaseResource):
             errback=errback,
         )
 
+    @property
+    def jobtypes(self, callback=None, errback=None):
+        return self._make_request(
+            "GET", "monitoring/jobtypes", callback=callback, errback=errback,
+        )
+
+    @property
+    def regions(self, callback=None, errback=None):
+        return self._make_request(
+            "GET", "monitoring/regions", callback=callback, errback=errback,
+        )
+
 
 class NotifyLists(resource.BaseResource):
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,0 +1,66 @@
+import pytest
+
+from ns1 import NS1
+from ns1.rest.account import Plan
+from ns1.rest.apikey import APIKey
+from ns1.rest.data import Feed, Source
+from ns1.rest.ipam import (
+    Addresses,
+    Networks,
+    Reservations,
+    Scopegroups,
+    Scopes,
+    Optiondefs,
+)
+from ns1.rest.monitoring import JobTypes, Monitors, NotifyLists, Regions
+from ns1.rest.records import Records
+from ns1.rest.stats import Stats
+from ns1.rest.team import Team
+from ns1.rest.user import User
+from ns1.rest.zones import Zones
+
+
+@pytest.fixture
+def ns1_config(config):
+    config.loadFromDict(
+        {
+            "endpoint": "api.nsone.net",
+            "default_key": "test1",
+            "keys": {
+                "test1": {
+                    "key": "key-1",
+                    "desc": "test key number 1",
+                    "writeLock": True,
+                }
+            },
+        }
+    )
+
+    return config
+
+
+@pytest.mark.parametrize("method, want", [
+    ("zones", Zones),
+    ("records", Records),
+    ("addresses", Addresses),
+    ("networks", Networks),
+    ("scope_groups", Scopegroups),
+    ("reservations", Reservations),
+    ("scopes", Scopes),
+    ("optiondefs", Optiondefs),
+    ("stats", Stats),
+    ("datasource", Source),
+    ("datafeed", Feed),
+    ("monitors", Monitors),
+    ("notifylists", NotifyLists),
+    ("monitoring_jobtypes", JobTypes),
+    ("monitoring_regions", Regions),
+    ("plan", Plan),
+    ("team", Team),
+    ("user", User),
+    ("apikey", APIKey),
+])
+def test_rest_interface(ns1_config, method, want):
+    client = NS1(config=ns1_config)
+    got = getattr(client, method)()
+    assert isinstance(got, want)

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -39,27 +39,30 @@ def ns1_config(config):
     return config
 
 
-@pytest.mark.parametrize("method, want", [
-    ("zones", Zones),
-    ("records", Records),
-    ("addresses", Addresses),
-    ("networks", Networks),
-    ("scope_groups", Scopegroups),
-    ("reservations", Reservations),
-    ("scopes", Scopes),
-    ("optiondefs", Optiondefs),
-    ("stats", Stats),
-    ("datasource", Source),
-    ("datafeed", Feed),
-    ("monitors", Monitors),
-    ("notifylists", NotifyLists),
-    ("monitoring_jobtypes", JobTypes),
-    ("monitoring_regions", Regions),
-    ("plan", Plan),
-    ("team", Team),
-    ("user", User),
-    ("apikey", APIKey),
-])
+@pytest.mark.parametrize(
+    "method, want",
+    [
+        ("zones", Zones),
+        ("records", Records),
+        ("addresses", Addresses),
+        ("networks", Networks),
+        ("scope_groups", Scopegroups),
+        ("reservations", Reservations),
+        ("scopes", Scopes),
+        ("optiondefs", Optiondefs),
+        ("stats", Stats),
+        ("datasource", Source),
+        ("datafeed", Feed),
+        ("monitors", Monitors),
+        ("notifylists", NotifyLists),
+        ("monitoring_jobtypes", JobTypes),
+        ("monitoring_regions", Regions),
+        ("plan", Plan),
+        ("team", Team),
+        ("user", User),
+        ("apikey", APIKey),
+    ],
+)
 def test_rest_interface(ns1_config, method, want):
     client = NS1(config=ns1_config)
     got = getattr(client, method)()

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -79,7 +79,7 @@ def test_rest_monitoring_crud(
     m._make_request.assert_called_once_with(method, url, **kwargs)
 
 
-@pytest.mark.parametrize("op", ["jobtypes", "regions",])
+@pytest.mark.parametrize("op", ["jobtypes", "regions"])
 def test_rest_monitoring_properties(monitoring_config, op):
     m = ns1.rest.monitoring.Monitors(monitoring_config)
     m._make_request = mock.MagicMock()

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -1,0 +1,136 @@
+import ns1.rest.monitoring
+import pytest
+
+try:  # Python 3.3 +
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+
+@pytest.fixture
+def monitoring_config(config):
+    config.loadFromDict(
+        {
+            "endpoint": "api.nsone.net",
+            "default_key": "test1",
+            "keys": {
+                "test1": {
+                    "key": "key-1",
+                    "desc": "test key number 1",
+                    "writeLock": True,
+                }
+            },
+        }
+    )
+
+    return config
+
+
+@pytest.mark.parametrize(
+    "op, args, method, url, kwargs",
+    [
+        (
+            "list",
+            None,
+            "GET",
+            "monitoring/jobs",
+            {"callback": None, "errback": None},
+        ),
+        (
+            "create",
+            [{}],
+            "PUT",
+            "monitoring/jobs",
+            {"body": {}, "callback": None, "errback": None},
+        ),
+        (
+            "retrieve",
+            ["my-job-id"],
+            "GET",
+            "monitoring/jobs/my-job-id",
+            {"callback": None, "errback": None},
+        ),
+        (
+            "update",
+            ["my-job-id", {}],
+            "POST",
+            "monitoring/jobs/my-job-id",
+            {"body": {}, "callback": None, "errback": None},
+        ),
+        (
+            "delete",
+            ["my-job-id"],
+            "DELETE",
+            "monitoring/jobs/my-job-id",
+            {"callback": None, "errback": None},
+        ),
+    ],
+)
+def test_rest_monitoring_crud(
+    monitoring_config, op, args, method, url, kwargs
+):
+    m = ns1.rest.monitoring.Monitors(monitoring_config)
+    m._make_request = mock.MagicMock()
+    operation = getattr(m, op)
+    if args is not None:
+        operation(*args)
+    else:
+        operation()
+    m._make_request.assert_called_once_with(method, url, **kwargs)
+
+
+@pytest.mark.parametrize("op", ["jobtypes", "regions",])
+def test_rest_monitoring_properties(monitoring_config, op):
+    m = ns1.rest.monitoring.Monitors(monitoring_config)
+    m._make_request = mock.MagicMock()
+    getattr(m, op)
+    m._make_request.assert_called_once_with(
+        "GET", "monitoring/{}".format(op), callback=None, errback=None
+    )
+
+
+@pytest.mark.parametrize(
+    "op, args, method, url, kwargs",
+    [
+        ("list", None, "GET", "lists", {"callback": None, "errback": None}),
+        (
+            "create",
+            [{}],
+            "PUT",
+            "lists",
+            {"body": {}, "callback": None, "errback": None},
+        ),
+        (
+            "retrieve",
+            ["my-list-id"],
+            "GET",
+            "lists/my-list-id",
+            {"callback": None, "errback": None},
+        ),
+        (
+            "update",
+            ["my-list-id", {}],
+            "POST",
+            "lists/my-list-id",
+            {"body": {}, "callback": None, "errback": None},
+        ),
+        (
+            "delete",
+            ["my-list-id"],
+            "DELETE",
+            "lists/my-list-id",
+            {"callback": None, "errback": None},
+        ),
+    ],
+)
+def test_rest_notifylists_crud(
+    monitoring_config, op, args, method, url, kwargs
+):
+    m = ns1.rest.monitoring.NotifyLists(monitoring_config)
+    m._make_request = mock.MagicMock()
+    operation = getattr(m, op)
+    if args is not None:
+        operation(*args)
+    else:
+        operation()
+    m._make_request.assert_called_once_with(method, url, **kwargs)

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -66,7 +66,7 @@ def monitoring_config(config):
         ),
     ],
 )
-def test_rest_monitoring_crud(
+def test_rest_monitoring_monitors(
     monitoring_config, op, args, method, url, kwargs
 ):
     m = ns1.rest.monitoring.Monitors(monitoring_config)
@@ -77,16 +77,6 @@ def test_rest_monitoring_crud(
     else:
         operation()
     m._make_request.assert_called_once_with(method, url, **kwargs)
-
-
-@pytest.mark.parametrize("op", ["jobtypes", "regions"])
-def test_rest_monitoring_properties(monitoring_config, op):
-    m = ns1.rest.monitoring.Monitors(monitoring_config)
-    m._make_request = mock.MagicMock()
-    getattr(m, op)
-    m._make_request.assert_called_once_with(
-        "GET", "monitoring/{}".format(op), callback=None, errback=None
-    )
 
 
 @pytest.mark.parametrize(
@@ -123,7 +113,7 @@ def test_rest_monitoring_properties(monitoring_config, op):
         ),
     ],
 )
-def test_rest_notifylists_crud(
+def test_rest_monitoring_notifylists(
     monitoring_config, op, args, method, url, kwargs
 ):
     m = ns1.rest.monitoring.NotifyLists(monitoring_config)
@@ -134,3 +124,21 @@ def test_rest_notifylists_crud(
     else:
         operation()
     m._make_request.assert_called_once_with(method, url, **kwargs)
+
+
+def test_rest_monitoring_jobtypes(monitoring_config):
+    m = ns1.rest.monitoring.JobTypes(monitoring_config)
+    m._make_request = mock.MagicMock()
+    m.list()
+    m._make_request.assert_called_once_with(
+        "GET", "monitoring/jobtypes", callback=None, errback=None
+    )
+
+
+def test_rest_monitoring_regions(monitoring_config):
+    m = ns1.rest.monitoring.Regions(monitoring_config)
+    m._make_request = mock.MagicMock()
+    m.list()
+    m._make_request.assert_called_once_with(
+        "GET", "monitoring/regions", callback=None, errback=None
+    )


### PR DESCRIPTION
Support for these endpoints added to rest.monitoring as classes,
with "high-level" entry points to the classes

Did not add "high level" methods for the class methods - doesn't seem worth it
unless we want to make models for the responses, and I don't see why we
would.

Also put together basic tests for the rest/monitoring file as a whole, and started a test file for `ns1/__init__`