### PR TITLE
pagination support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ Contributions
 Pull Requests and issues are welcome. See the [NS1 Contribution Guidelines](https://github.com/ns1/community) for more information.
 
 Our CI process will lint and check for formatting issues with `flake8` and
-`black`. 
+`black`.
 It is suggested to run these checks prior to submitting a pull request and fix
 any issues:
 ```

--- a/examples/zones.py
+++ b/examples/zones.py
@@ -15,6 +15,12 @@ api = NS1()
 # to load an alternate configuration file:
 # api = NS1(configFile='/etc/ns1/api.json')
 
+# turn on "follow pagination". This will handle paginated responses for
+# zone list and the records for a zone retrieve. It's off by default to
+# avoid a breaking change
+config = api.config
+config["follow_pagination"] = True
+
 ######################
 # LOAD / CREATE ZONE #
 ######################

--- a/ns1/config.py
+++ b/ns1/config.py
@@ -65,6 +65,9 @@ class Config:
         if "ddi" not in self._data:
             self._data["ddi"] = False
 
+        if "follow_pagination" not in self._data:
+            self._data["follow_pagination"] = False
+
     def createFromAPIKey(self, apikey, maybeWriteDefault=False):
         """
         Create a basic config from a single API key

--- a/ns1/helpers.py
+++ b/ns1/helpers.py
@@ -1,3 +1,5 @@
+import re
+
 from threading import Lock
 
 
@@ -13,3 +15,35 @@ class SingletonMixin(object):
                 if cls._instance is None:
                     cls._instance = object.__new__(cls, *args, **kwargs)
         return cls._instance
+
+
+def get_next_page(headers):
+    headers = {k.lower(): v for k, v in headers.items()}
+    links = _parse_header_links(headers.get("link", ""))
+    for link in links:
+        if link.get("rel") == "next":
+            return link.get("url").replace("http://", "https://")
+
+
+# cribbed from requests, since we don't want to require it as a dependency
+def _parse_header_links(value):
+    """Return a dict of parsed link headers proxies.
+    i.e. Link: <http:/.../front.jpeg>; rel=front; type="image/jpeg",<http://.../back.jpeg>; rel=back;type="image/jpeg"
+    """
+    links = []
+    replace_chars = " '\""
+    for val in re.split(", *<", value):
+        try:
+            url, params = val.split(";", 1)
+        except ValueError:
+            url, params = val, ""
+        link = {}
+        link["url"] = url.strip("<> '\"")
+        for param in params.split(";"):
+            try:
+                key, value = param.split("=")
+            except ValueError:
+                break
+            link[key.strip(replace_chars)] = value.strip(replace_chars)
+        links.append(link)
+    return links

--- a/ns1/rest/transport/base.py
+++ b/ns1/rest/transport/base.py
@@ -18,6 +18,7 @@ class TransportBase(object):
             "ignore-ssl-errors", self._config.get("ignore-ssl-errors", False)
         )
         self._rate_limit_func = self._config.getRateLimitingFunc()
+        self._follow_pagination = self._config.get("follow_pagination", False)
 
     def _logHeaders(self, headers):
         if self._config["verbosity"] > 0:

--- a/ns1/rest/transport/basic.py
+++ b/ns1/rest/transport/basic.py
@@ -143,7 +143,7 @@ class BasicTransport(TransportBase):
             data = data.encode("utf-8")
 
         resp_headers, jsonOut = self._send(url, headers, data, method, errback)
-        if pagination_handler is not None:
+        if self._follow_pagination and pagination_handler is not None:
             next_page = get_next_page(resp_headers)
             while next_page is not None:
                 self._log.debug("following pagination to: %s" % (next_page))

--- a/ns1/rest/transport/requests.py
+++ b/ns1/rest/transport/requests.py
@@ -111,7 +111,7 @@ class RequestsTransport(TransportBase):
         resp_headers, jsonOut = self._send(
             method, url, headers, data, files, params, errback
         )
-        if pagination_handler is not None:
+        if self._follow_pagination and pagination_handler is not None:
             next_page = get_next_page(resp_headers)
             while next_page is not None:
                 self._log.debug("following pagination to: %s" % next_page)

--- a/ns1/rest/transport/requests.py
+++ b/ns1/rest/transport/requests.py
@@ -5,6 +5,7 @@
 #
 from __future__ import absolute_import
 
+from ns1.helpers import get_next_page
 from ns1.rest.transport.base import TransportBase
 from ns1.rest.errors import (
     ResourceException,
@@ -43,18 +44,7 @@ class RequestsTransport(TransportBase):
             "remaining": int(headers.get("X-RateLimit-Remaining", 100)),
         }
 
-    def send(
-        self,
-        method,
-        url,
-        headers=None,
-        data=None,
-        params=None,
-        files=None,
-        callback=None,
-        errback=None,
-    ):
-        self._logHeaders(headers)
+    def _send(self, method, url, headers, data, files, params, errback):
         resp = self.REQ_MAP[method](
             url,
             headers=headers,
@@ -92,7 +82,7 @@ class RequestsTransport(TransportBase):
         # TODO make sure json is valid if a body is returned
         if resp.text:
             try:
-                jsonOut = resp.json()
+                return response_headers, resp.json()
             except ValueError:
                 if errback:
                     errback(resp)
@@ -102,12 +92,38 @@ class RequestsTransport(TransportBase):
                         "invalid json in response", resp, resp.text
                     )
         else:
-            jsonOut = None
+            return response_headers, None
+
+    def send(
+        self,
+        method,
+        url,
+        headers=None,
+        data=None,
+        params=None,
+        files=None,
+        callback=None,
+        errback=None,
+        pagination_handler=None,
+    ):
+        self._logHeaders(headers)
+
+        resp_headers, jsonOut = self._send(
+            method, url, headers, data, files, params, errback
+        )
+        if pagination_handler is not None:
+            next_page = get_next_page(resp_headers)
+            while next_page is not None:
+                self._log.debug("following pagination to: %s" % next_page)
+                next_headers, next_json = self._send(
+                    method, next_page, headers, data, files, params, errback
+                )
+                jsonOut = pagination_handler(jsonOut, next_json)
+                next_page = get_next_page(next_headers)
 
         if callback:
             return callback(jsonOut)
-        else:
-            return jsonOut
+        return jsonOut
 
 
 TransportBase.REGISTRY["requests"] = RequestsTransport

--- a/ns1/rest/transport/twisted.py
+++ b/ns1/rest/transport/twisted.py
@@ -152,9 +152,11 @@ class TwistedTransport(TransportBase):
             d.addCallback(self._callback, request_data)
             d.addErrback(self._errback, request_data["user_errback"])
             # ... and a callback to our pagination_handler
-            d.addCallback(lambda next_json: request_data["pagination_handler"](
-                jsonOut, next_json
-            ))
+            d.addCallback(
+                lambda next_json: request_data["pagination_handler"](
+                    jsonOut, next_json
+                )
+            )
             return d
 
         # our (non-deferred) response goes back up the chain

--- a/ns1/rest/transport/twisted.py
+++ b/ns1/rest/transport/twisted.py
@@ -127,8 +127,6 @@ class TwistedTransport(TransportBase):
         return d
 
     def _errback(self, failure, user_errback):
-        # print "failure: %s" % failure.printTraceback()
-
         if user_errback:
             return user_errback(failure)
         else:

--- a/ns1/rest/transport/twisted.py
+++ b/ns1/rest/transport/twisted.py
@@ -8,6 +8,7 @@ import json
 import random
 import sys
 
+from ns1.helpers import get_next_page
 from ns1.rest.errors import AuthException
 from ns1.rest.errors import RateLimitException
 from ns1.rest.errors import ResourceException
@@ -117,17 +118,46 @@ class TwistedTransport(TransportBase):
 
         self.agent = Agent(reactor, policy, connectTimeout=self._timeout)
 
-    def _callback(self, response, user_callback, data, headers):
+    def _callback(self, response, request_data):
         d = readBody(response)
-        d.addCallback(self._onBody, response, user_callback, data, headers)
+        d.addCallback(self._onBody, response, request_data)
         d.addCallback(self._handleRateLimiting)
+        d.addCallback(self._handlePagination, request_data)
 
         return d
+
+    def _errback(self, failure, user_errback):
+        # print "failure: %s" % failure.printTraceback()
+
+        if user_errback:
+            return user_errback(failure)
+        else:
+            if failure.check(ResourceException, RateLimitException):
+                raise failure.value
+            raise ResourceException(failure.getErrorMessage())
 
     def _handleRateLimiting(self, data):
         headers, jsonOut = data
         self._rate_limit_func(self._rateLimitHeaders(headers))
+        return headers, jsonOut
 
+    def _handlePagination(self, data, request_data):
+        headers, jsonOut = data
+        link = {"link": headers.getRawHeaders("Link", [""])[0]}
+        next_page = get_next_page(link)
+        if next_page:
+            self._log.debug("following pagination to: {}".format(next_page))
+            # kickoff new deferred, with the original callbacks ...
+            d = request_data["request_func"](next_page)
+            d.addCallback(self._callback, request_data)
+            d.addErrback(self._errback, request_data["user_errback"])
+            # ... and a callback to our pagination_handler
+            d.addCallback(lambda next_json: request_data["pagination_handler"](
+                jsonOut, next_json
+            ))
+            return d
+
+        # our (non-deferred) response goes back up the chain
         return jsonOut
 
     def _rateLimitHeaders(self, headers):
@@ -140,15 +170,15 @@ class TwistedTransport(TransportBase):
             ),
         }
 
-    def _onBody(self, body, response, user_callback, data, headers):
-        self._logHeaders(headers)
+    def _onBody(self, body, response, request_data):
+        self._logHeaders(request_data["headers"])
         self._log.debug(
             "%s %s %s %s"
             % (
                 response.request.method,
                 response.request.absoluteURI,
                 response.code,
-                data,
+                request_data["data"],
             )
         )
 
@@ -181,6 +211,7 @@ class TwistedTransport(TransportBase):
         else:
             jsonOut = None
 
+        user_callback = request_data["user_callback"]
         if user_callback:
             # set these in case callback throws, so we have them for errback
             self.response = response
@@ -190,29 +221,12 @@ class TwistedTransport(TransportBase):
         else:
             return responseHeaders, jsonOut
 
-    def _errback(self, failure, user_errback):
-        # print "failure: %s" % failure.printTraceback()
-
-        if user_errback:
-            return user_errback(failure)
-        else:
-            if failure.check(ResourceException, RateLimitException):
-                raise failure.value
-            raise ResourceException(failure.getErrorMessage())
-
-    def send(
-        self,
-        method,
-        url,
-        headers=None,
-        data=None,
-        files=None,
-        params=None,
-        callback=None,
-        errback=None,
-    ):
+    def _request_func(self, method, headers, data, files):
+        """
+        Apply the basic request parameters that won't change over subrequests,
+        return a function that takes a url and returns a (new) deferred.
+        """
         bProducer = None
-
         if data:
             bProducer = StringProducer(data)
         elif files:
@@ -231,18 +245,52 @@ class TwistedTransport(TransportBase):
                 "Content-Type"
             ] = "multipart/form-data; boundary={}".format(boundary)
             bProducer = FileBodyProducer(StringIO.StringIO(body))
-        theaders = None
 
-        if params is not None:
-            qstr = urlencode(params)
-            url = "?".join((url, qstr))
+        theaders = (
+            Headers({str(k): [str(v)] for (k, v) in headers.items()})
+            if headers
+            else None
+        )
 
-        if headers:
-            theaders = Headers(
-                {str(k): [str(v)] for (k, v) in headers.items()}
+        def req(url):
+            # explicit encoding is so this works for py2 and py3
+            return self.agent.request(
+                method.encode("utf-8"),
+                url.encode("utf-8"),
+                theaders,
+                bProducer,
             )
-        d = self.agent.request(method, str(url), theaders, bProducer)
-        d.addCallback(self._callback, callback, data, headers)
+
+        return req
+
+    def send(
+        self,
+        method,
+        url,
+        headers=None,
+        data=None,
+        files=None,
+        params=None,
+        callback=None,
+        errback=None,
+        pagination_handler=None,
+    ):
+        if params is not None:
+            url = "?".join((url, urlencode(params)))
+
+        # gather everything we need to make more requests...
+        request_data = {
+            "data": data,
+            "headers": headers,
+            "pagination_handler": pagination_handler,
+            "request_func": self._request_func(method, headers, data, files),
+            "user_callback": callback,
+            "user_errback": errback,
+        }
+
+        d = request_data["request_func"](url)
+        # ... and pass it along
+        d.addCallback(self._callback, request_data)
         d.addErrback(self._errback, errback)
 
         return d

--- a/ns1/rest/transport/twisted.py
+++ b/ns1/rest/transport/twisted.py
@@ -141,6 +141,8 @@ class TwistedTransport(TransportBase):
 
     def _handlePagination(self, data, request_data):
         headers, jsonOut = data
+        if not self._follow_pagination:
+            return jsonOut
         link = {"link": headers.getRawHeaders("Link", [""])[0]}
         next_page = get_next_page(link)
         if next_page:

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -3,7 +3,6 @@
 #
 # License under The MIT License (MIT). See LICENSE in project root.
 #
-from copy import deepcopy
 
 from . import resource
 

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -105,15 +105,11 @@ class Zones(resource.BaseResource):
 
 # successive pages just extend the list of zones
 def zone_list_pagination(curr_json, next_json):
-    # avoid mutating our inputs. not an issue now, but so it doesn't become one
-    out = deepcopy(curr_json)
-    out.extend(next_json)
-    return out
+    curr_json.extend(next_json)
+    return curr_json
 
 
 # successive pages only differ in the "records" list
 def zone_retrieve_pagination(curr_json, next_json):
-    # avoid mutating our inputs. not an issue now, but so it doesn't become one
-    out = deepcopy(curr_json)
-    out["records"].extend(next_json["records"])
-    return out
+    curr_json["records"].extend(next_json["records"])
+    return curr_json

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -3,6 +3,7 @@
 #
 # License under The MIT License (MIT). See LICENSE in project root.
 #
+from copy import deepcopy
 
 from . import resource
 
@@ -71,7 +72,11 @@ class Zones(resource.BaseResource):
 
     def list(self, callback=None, errback=None):
         return self._make_request(
-            "GET", "%s" % self.ROOT, callback=callback, errback=errback
+            "GET",
+            "%s" % self.ROOT,
+            callback=callback,
+            errback=errback,
+            pagination_handler=zone_list_pagination,
         )
 
     def retrieve(self, zone, callback=None, errback=None):
@@ -80,6 +85,7 @@ class Zones(resource.BaseResource):
             "%s/%s" % (self.ROOT, zone),
             callback=callback,
             errback=errback,
+            pagination_handler=zone_retrieve_pagination,
         )
 
     def search(self, zone, q=None, has_geo=False, callback=None, errback=None):
@@ -95,3 +101,19 @@ class Zones(resource.BaseResource):
             callback=callback,
             errback=errback,
         )
+
+
+# successive pages just extend the list of zones
+def zone_list_pagination(curr_json, next_json):
+    # avoid mutating our inputs. not an issue now, but so it doesn't become one
+    out = deepcopy(curr_json)
+    out.extend(next_json)
+    return out
+
+
+# successive pages only differ in the "records" list
+def zone_retrieve_pagination(curr_json, next_json):
+    # avoid mutating our inputs. not an issue now, but so it doesn't become one
+    out = deepcopy(curr_json)
+    out["records"].extend(next_json["records"])
+    return out

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -12,6 +12,7 @@ defaults = {
     "api_version": "v1",
     "cli": {},
     "ddi": False,
+    "follow_pagination": False,
 }
 
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -91,6 +91,13 @@ def test_singleton_mixin_with_concurrency(queue_class, process, repetitions):
         ),
         (
             {
+                "Link": "<https://a.co/b.jpg>; rel=next; type='image/jpeg',"
+                "<http://b.co/c.jpg>; rel=last;type='image/jpeg'"
+            },
+            "https://a.co/b.jpg",
+        ),
+        (
+            {
                 "link": "<http://a.co/b.jpg>; rel=front; type='image/jpeg',"
                 "<http://b.co/c.jpg>; rel=back;type='image/jpeg'"
             },

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -77,19 +77,22 @@ def test_singleton_mixin_with_concurrency(queue_class, process, repetitions):
         ({}, None),
         (
             {
-                "link": "<http://a.co/b.jpg>; rel=next; type='image/jpeg',<http://b.co/c.jpg>; rel=last;type='image/jpeg'"
+                "link": "<http://a.co/b.jpg>; rel=next; type='image/jpeg',"
+                "<http://b.co/c.jpg>; rel=last;type='image/jpeg'"
             },
             "https://a.co/b.jpg",
         ),
         (
             {
-                "Link": "<http://a.co/b.jpg>; rel=next; type='image/jpeg',<http://b.co/c.jpg>; rel=last;type='image/jpeg'"
+                "Link": "<http://a.co/b.jpg>; rel=next; type='image/jpeg',"
+                "<http://b.co/c.jpg>; rel=last;type='image/jpeg'"
             },
             "https://a.co/b.jpg",
         ),
         (
             {
-                "link": "<http://a.co/b.jpg>; rel=front; type='image/jpeg',<http://b.co/c.jpg>; rel=back;type='image/jpeg'"
+                "link": "<http://a.co/b.jpg>; rel=front; type='image/jpeg',"
+                "<http://b.co/c.jpg>; rel=back;type='image/jpeg'"
             },
             None,
         ),

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -69,3 +69,37 @@ def test_singleton_mixin_with_concurrency(queue_class, process, repetitions):
         assert a is b
         assert a not in seen_uuids
         seen_uuids.add(a)
+
+
+@pytest.mark.parametrize(
+    "headers, want",
+    [
+        ({}, None),
+        (
+            {
+                "link": "<http://a.co/b.jpg>; rel=next; type='image/jpeg',<http://b.co/c.jpg>; rel=last;type='image/jpeg'"
+            },
+            "https://a.co/b.jpg",
+        ),
+        (
+            {
+                "Link": "<http://a.co/b.jpg>; rel=next; type='image/jpeg',<http://b.co/c.jpg>; rel=last;type='image/jpeg'"
+            },
+            "https://a.co/b.jpg",
+        ),
+        (
+            {
+                "link": "<http://a.co/b.jpg>; rel=front; type='image/jpeg',<http://b.co/c.jpg>; rel=back;type='image/jpeg'"
+            },
+            None,
+        ),
+    ],
+)
+def test_next_page(headers, want):
+    """
+    it should get the "next" link
+    it should "https-ify" http links
+    it is not case-sensitive when reading header dict
+    """
+    got = ns1.helpers.get_next_page(headers)
+    assert got == want

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -67,6 +67,7 @@ def test_basic_transport_pagination():
     config = Config()
     config.createFromAPIKey("AAAAAAAAAAAAAAAAA")
     config["transport"] = "basic"
+    config["follow_pagination"] = True
 
     resource = BaseResource(config)
 
@@ -124,6 +125,7 @@ def test_requests_transport_pagination():
     config = Config()
     config.createFromAPIKey("AAAAAAAAAAAAAAAAA")
     config["transport"] = "requests"
+    config["follow_pagination"] = True
 
     resource = BaseResource(config)
 

--- a/tests/unit/test_twisted.py
+++ b/tests/unit/test_twisted.py
@@ -1,0 +1,139 @@
+import json
+import pytest
+
+from copy import deepcopy
+from ns1.config import Config
+from ns1.rest.resource import BaseResource
+from ns1.rest.transport.twisted import have_twisted, TwistedTransport
+
+try:  # Python 3.3 +
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+
+class MockHeaders(object):
+    """
+    lookups should return lists
+    """
+    def __init__(self, lookup=None):
+        self._lookup = {} if lookup is None else lookup
+
+    def getRawHeaders(self, key, default):
+        return self._lookup.get(key, default)
+
+
+class MockResponse(object):
+    """
+    pretend we're a twisted.web.client.response
+    """
+    method = "GET"
+    absoluteURI = "http://"
+
+    def __init__(self, code=200, phrase="200 OK", headers=None, body=None):
+        self.body = {} if body is None else body
+        self.code = code
+        self.headers = MockHeaders(headers)
+        self.phrase = phrase
+        self.request = self
+
+    def deliverBody(self, protocol):
+        protocol.dataReceived(json.dumps(self.body).encode('utf-8'))
+        protocol.connectionLost(self)
+
+    def check(self, reason):
+        return True
+
+
+@pytest.mark.skipif(not have_twisted, reason="twisted not found")
+def test_twisted():
+    """
+    basic test exercising rate-limiting, pagination, and response
+    flow during a request.
+    """
+    from twisted.internet import defer, reactor
+
+    config = Config()
+    config.createFromAPIKey("AAAAAAAAAAAAAAAAA")
+    config["transport"] = "twisted"
+
+    resource = BaseResource(config)
+
+    assert resource._config == config
+    assert isinstance(resource._transport, TwistedTransport)
+
+    # setup mocks
+
+    # rate-limiting
+    resource._transport._rate_limit_func = mock.Mock()
+
+    # first response
+    d1 = defer.Deferred()
+    d1.addCallback(lambda x: MockResponse(
+        headers={"Link": ["<http://a.co/b>; rel=next;"]},
+        body=[{"1st": ""}]
+    ))
+    reactor.callLater(0, d1.callback, None)
+
+    # second response
+    d2 = defer.Deferred()
+    d2.addCallback(lambda x: MockResponse(body=[{"2nd": ""}]))
+    reactor.callLater(0, d2.callback, None)
+
+    resource._transport.agent.request = mock.Mock(side_effect=[d1, d2])
+
+    # pagination
+    def _pagination_handler(jsonOut, next_json):
+        out = deepcopy(jsonOut)
+        out.extend(next_json)
+        return out
+    pagination_handler = mock.Mock(side_effect=_pagination_handler)
+
+    # callbacks
+
+    def _cb(result):
+        reactor.stop()
+
+    def _eb(err):
+        reactor.stop()
+
+    cb = mock.Mock(side_effect=_cb)
+    eb = mock.Mock(side_effect=_eb)
+
+    @defer.inlineCallbacks
+    def req():
+        result = yield resource._make_request(
+            "GET", "my_path", pagination_handler=pagination_handler
+        )
+        defer.returnValue(result)
+
+    # call our deferred request and add callbacks
+    res = req()
+    res.addCallbacks(cb, eb)
+
+    # RUN THE LOOP
+    reactor.run()
+
+    # check our work
+
+    # we made two requests
+    resource._transport.agent.request.call_count == 2
+
+    # we hit our rate-limit function twice, once per request
+    call_args_list = resource._transport._rate_limit_func.call_args_list
+    assert len(call_args_list) == 2
+    for c in call_args_list:
+        args, kwargs = c
+        assert args == (
+            {"by": "customer", "limit": 10, "period": 1, "remaining": 100},
+        )
+        assert kwargs == {}
+
+    # we hit our pagination_handler once, to put the two results together
+    pagination_handler.assert_called_once_with([{"1st": ""}], [{"2nd": ""}])
+
+    # our final result is correct
+    cb.assert_called_once_with([{"1st": ""}, {"2nd": ""}])
+
+    # errback was not called
+    eb.assert_not_called()

--- a/tests/unit/test_twisted.py
+++ b/tests/unit/test_twisted.py
@@ -58,6 +58,7 @@ def test_twisted():
     config = Config()
     config.createFromAPIKey("AAAAAAAAAAAAAAAAA")
     config["transport"] = "twisted"
+    config["follow_pagination"] = True
 
     resource = BaseResource(config)
 

--- a/tests/unit/test_twisted.py
+++ b/tests/unit/test_twisted.py
@@ -88,6 +88,7 @@ def test_twisted():
 
     # pagination
     def _pagination_handler(jsonOut, next_json):
+        # don't mutate args, since assertions operate on references to them
         out = deepcopy(jsonOut)
         out.extend(next_json)
         return out

--- a/tests/unit/test_twisted.py
+++ b/tests/unit/test_twisted.py
@@ -16,6 +16,7 @@ class MockHeaders(object):
     """
     lookups should return lists
     """
+
     def __init__(self, lookup=None):
         self._lookup = {} if lookup is None else lookup
 
@@ -27,6 +28,7 @@ class MockResponse(object):
     """
     pretend we're a twisted.web.client.response
     """
+
     method = "GET"
     absoluteURI = "http://"
 
@@ -38,7 +40,7 @@ class MockResponse(object):
         self.request = self
 
     def deliverBody(self, protocol):
-        protocol.dataReceived(json.dumps(self.body).encode('utf-8'))
+        protocol.dataReceived(json.dumps(self.body).encode("utf-8"))
         protocol.connectionLost(self)
 
     def check(self, reason):
@@ -69,10 +71,12 @@ def test_twisted():
 
     # first response
     d1 = defer.Deferred()
-    d1.addCallback(lambda x: MockResponse(
-        headers={"Link": ["<http://a.co/b>; rel=next;"]},
-        body=[{"1st": ""}]
-    ))
+    d1.addCallback(
+        lambda x: MockResponse(
+            headers={"Link": ["<http://a.co/b>; rel=next;"]},
+            body=[{"1st": ""}],
+        )
+    )
     reactor.callLater(0, d1.callback, None)
 
     # second response
@@ -87,6 +91,7 @@ def test_twisted():
         out = deepcopy(jsonOut)
         out.extend(next_json)
         return out
+
     pagination_handler = mock.Mock(side_effect=_pagination_handler)
 
     # callbacks

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -31,7 +31,11 @@ def test_rest_zone_list(zones_config):
     z._make_request = mock.MagicMock()
     z.list()
     z._make_request.assert_called_once_with(
-        "GET", "zones", callback=None, errback=None
+        "GET",
+        "zones",
+        callback=None,
+        errback=None,
+        pagination_handler=ns1.rest.zones.zone_list_pagination,
     )
 
 
@@ -41,7 +45,11 @@ def test_rest_zone_retrieve(zones_config, zone, url):
     z._make_request = mock.MagicMock()
     z.retrieve(zone)
     z._make_request.assert_called_once_with(
-        "GET", url, callback=None, errback=None
+        "GET",
+        url,
+        callback=None,
+        errback=None,
+        pagination_handler=ns1.rest.zones.zone_retrieve_pagination,
     )
 
 


### PR DESCRIPTION
Follows pagination for supported endpoints. Not user-configurable.

* helpers.py: get_next_page parses headers for "next" url
* rest/transport: send methods take an optional pagination_handler,
  if present and a next page is found, accumulate the results via
  the handler function
* rest/zones.py: add pagination_handlers for list and retrieve, pass
  them to make_request
* try to write some actually useful tests exercising twisted transport.
  basic and ugly but don't rely on twisted test frameworks to run.