### PR TITLE
initial support for DNS views

### DIFF
--- a/examples/dns-views-compatibility.py
+++ b/examples/dns-views-compatibility.py
@@ -1,0 +1,103 @@
+"""
+DNS views allow for <blurb here>
+
+This means an FQDN can now appear in more than one zone. We have implemented
+views in a back-compatible way, so if you do not intend to use them, you can
+largely continue to use the API as you've done before.
+
+COMPATIBILITY
+
+Until now, the unique identifier of a zone in the API has been the FQDN. This
+appears both in the URL for API requests and in the 'zone' field of zones and
+records. The API throws an error if the URL and field in the body do not match.
+
+Going forward, the unique identifier of the zone is "decoupled" from the 'zone'
+field. The reference in the URL can now be an arbitrary string, unique within
+your account. This identifier is passed and returned in the 'name' field for
+zones, and the 'zone_name' field for records. You may of course continue to use
+the FQDN as the identifier - in fact, if you are not using "views", it is
+recommended that you do so. However:
+
+* Mismatches between the zone name in the URL and the 'zone' field are no
+  longer validated to match, as it is no longer an invalid condition.
+* New field 'name' on zone responses. Also a new 'views' array
+* New field 'zone_name' on record responses
+
+Crucially, if you are NOT using "views", then the 'zone' and 'name' fields on
+the zone will probably have the same value, but the unique identifier for the
+zone is ALWAYS the value in the 'name' field. So in general, code should be
+written or updated to prefer the 'name/zone_name' fields for identification,
+and when using "views" functionality, calling code MUST be
+"name/zone_name aware".
+
+SDK CHANGES
+
+There are some new endpoints for views functionality, which are discusses in
+another example. This note is just about existing methods. Currently, only the
+'rest interface' is ensured to be 'name/zone_name' aware:
+
+* the "zone/z" argument to CRUD methods is always considered the
+  "name/zone_name"
+* On create, when the "name" is not the FQDN, the FQDN must be passed in
+  the 'zone' field, as we still need to know the FQDN for assignment.
+
+As noted, not all SDK "interfaces" are "DNS views aware". When working with DNS
+views, care should be taken if using SDK methods not shown here, such as the
+"high level" interfaces. Due to compatibility, you may "successfully" end up
+doing the wrong thing!
+"""
+
+from ns1 import NS1
+
+client = NS1()
+
+# the resources we will be using
+zones = client.zones()
+records = client.records()
+
+
+# create a named zone
+# ===================
+# "zone" must be passed in args
+data = {"zone": "example.com", "ttl": 900}
+zone_object = zones.create("example-name", **data)
+
+
+# add a record
+# ============
+data = {"zone": "example.com", "ttl": 888}
+record_object = records.create("example-name", "sub.example.com", "A", **data)
+
+
+# retrieve a record
+# =================
+record_object = records.retrieve("example-name", "sub.example.com", "A")
+
+
+# update a record
+# ===============
+data = {"ttl": 888}
+record_one = records.update("example-name", "sub.example.com", "A", **data)
+
+
+# delete a record
+# ===============
+delete_response = records.delete("example-name", "sub.example.com", "A")
+
+
+# retrieve zone
+# =============
+zone_object = zones.retrieve("example-name")
+# search is by "name"
+search_results = zones.search("example")
+
+
+# update named zone
+# =================
+data = {"ttl": 999}
+zone_one = zones.update("example-name", **data)
+
+
+# delete named zone
+# =================
+delete_response = zones.delete("example-name")

--- a/examples/dns-views.py
+++ b/examples/dns-views.py
@@ -1,0 +1,112 @@
+"""
+DNS views example
+
+Settiing up "internal" and "external" views of a zone
+"""
+
+from base64 import b64encode
+
+from ns1 import NS1
+
+client = NS1()
+
+# The resources we will be using
+zones = client.zones()
+records = client.records()
+acls = client.acls()
+tsig = client.tsig()
+views = client.views()
+
+
+def run():
+    # create our zones and records. explicitly setting empty networks keeps
+    # things from propagating. See dns-views-compatibility for more details on
+    # zone and record calls
+    zone_internal = zones.create(
+        "zone-internal", zone="example.com", networks=[]
+    )
+    record_internal = records.create(
+        zone_internal["name"],
+        "example.com",
+        "A",
+        answers=[{"answer": ["1.1.1.1"]}],
+    )
+    zone_external = zones.create(
+        "zone-external", zone="example.com", networks=[]
+    )
+    record_external = records.create(
+        zone_external["name"],
+        "example.com",
+        "A",
+        answers=[{"answer": ["2.2.2.2"]}],
+    )
+
+    # we'll use tsig on one of our acls
+    tsig_internal = tsig.create(
+        "example-tsig",
+        algorithm="hmac-sha512",
+        secret=b64encode(b"example-secret").decode(),
+    )
+
+    # create an acl for each view
+    acl_internal = acls.create(
+        "acl-internal",
+        src_prefixes=["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"],
+        tsig_keys=[tsig_internal["name"]],
+    )
+    acl_external = acls.create("acl-external", src_prefixes=["0.0.0.0/0"])
+
+    # create views. this associates zones, acls, and networks, and as the networks
+    # are set, triggers propagation
+    # Note: preference reordering is expensive, try to leave space for insertions
+    view_internal = views.create(
+        "view-internal",
+        read_acls=[acl_internal["name"]],
+        zones=[zone_internal["name"]],
+        networks=[1],
+        preference=10,
+    )
+    view_external = views.create(
+        "view-external",
+        read_acls=[acl_external["name"]],
+        zones=[zone_external["name"]],
+        networks=[1],
+        preference=20,
+    )
+    return (
+        zone_internal,
+        zone_external,
+        record_internal,
+        record_external,
+        acl_external,
+        acl_internal,
+        view_internal,
+        view_external,
+        tsig_internal,
+    )
+
+
+def verify():
+    print(acls.list())
+    print(tsig.list())
+    print(views.list())
+    print(zones.list())
+
+
+def cleanup():
+    # delete all the things we created
+    zones.delete("zone-internal")
+    zones.delete("zone-external")
+    views.delete("view-internal")
+    views.delete("view-external")
+    acls.delete("acl-internal")
+    acls.delete("acl-external")
+    tsig.delete("example-tsig")
+
+
+# Note: this will do real things to your real account, and you may want to
+# config your client differently before running things
+
+# run()
+# verify()
+# cleanup()

--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -233,6 +233,36 @@ class NS1:
 
         return ns1.rest.apikey.APIKey(self.config)
 
+    def acls(self):
+        """
+        Return a new raw REST interface to ACL resources
+
+        :rtype: :py:class:`ns1.rest.acls.ACLs`
+        """
+        import ns1.rest.acls
+
+        return ns1.rest.acls.ACLs(self.config)
+
+    def tsig(self):
+        """
+        Return a new raw REST interface to TSIG resources
+
+        :rtype: :py:class:`ns1.rest.tsig.TSIGs`
+        """
+        import ns1.rest.tsig
+
+        return ns1.rest.tsig.TSIGs(self.config)
+
+    def views(self):
+        """
+        Return a new raw REST interface to views resources
+
+        :rtype: :py:class:`ns1.rest.views.Views`
+        """
+        import ns1.rest.views
+
+        return ns1.rest.views.Views(self.config)
+
     # HIGH LEVEL INTERFACE
     def loadZone(self, zone, callback=None, errback=None):
         """

--- a/ns1/rest/acls.py
+++ b/ns1/rest/acls.py
@@ -1,0 +1,59 @@
+#
+# Copyright (c) 2014 NSONE, Inc.
+#
+# License under The MIT License (MIT). See LICENSE in project root.
+#
+
+from . import resource
+
+
+class ACLs(resource.BaseResource):
+
+    ROOT = "acls"
+
+    BOOL_FIELDS = []
+    INT_FIELDS = []
+    PASSTHRU_FIELDS = ["src_prefixes", "tsig_keys", "gss_tsig_identities"]
+
+    def list(self, callback=None, errback=None):
+        return self._make_request(
+            "GET", "%s" % self.ROOT, callback=callback, errback=errback,
+        )
+
+    def retrieve(self, name, callback=None, errback=None):
+        return self._make_request(
+            "GET",
+            "%s/%s" % (self.ROOT, name),
+            callback=callback,
+            errback=errback,
+        )
+
+    def create(self, name, callback=None, errback=None, **kwargs):
+        body = {}
+        self._buildStdBody(body, kwargs)
+        return self._make_request(
+            "PUT",
+            "%s/%s" % (self.ROOT, name),
+            body=body,
+            callback=callback,
+            errback=errback,
+        )
+
+    def update(self, name, callback=None, errback=None, **kwargs):
+        body = {}
+        self._buildStdBody(body, kwargs)
+        return self._make_request(
+            "POST",
+            "%s/%s" % (self.ROOT, name),
+            body=body,
+            callback=callback,
+            errback=errback,
+        )
+
+    def delete(self, name, callback=None, errback=None):
+        return self._make_request(
+            "DELETE",
+            "%s/%s" % (self.ROOT, name),
+            callback=callback,
+            errback=errback,
+        )

--- a/ns1/rest/tsig.py
+++ b/ns1/rest/tsig.py
@@ -1,0 +1,62 @@
+#
+# Copyright (c) 2014 NSONE, Inc.
+#
+# License under The MIT License (MIT). See LICENSE in project root.
+#
+
+from . import resource
+
+
+class TSIGs(resource.BaseResource):
+
+    ROOT = "tsig"
+
+    BOOL_FIELDS = []
+    INT_FIELDS = []
+    PASSTHRU_FIELDS = [
+        "algorithm",
+        "secret",
+    ]
+
+    def list(self, callback=None, errback=None):
+        return self._make_request(
+            "GET", "%s" % self.ROOT, callback=callback, errback=errback,
+        )
+
+    def retrieve(self, name, callback=None, errback=None):
+        return self._make_request(
+            "GET",
+            "%s/%s" % (self.ROOT, name),
+            callback=callback,
+            errback=errback,
+        )
+
+    def create(self, name, callback=None, errback=None, **kwargs):
+        body = {}
+        self._buildStdBody(body, kwargs)
+        return self._make_request(
+            "PUT",
+            "%s/%s" % (self.ROOT, name),
+            body=body,
+            callback=callback,
+            errback=errback,
+        )
+
+    def update(self, name, callback=None, errback=None, **kwargs):
+        body = {}
+        self._buildStdBody(body, kwargs)
+        return self._make_request(
+            "POST",
+            "%s/%s" % (self.ROOT, name),
+            body=body,
+            callback=callback,
+            errback=errback,
+        )
+
+    def delete(self, name, callback=None, errback=None):
+        return self._make_request(
+            "DELETE",
+            "%s/%s" % (self.ROOT, name),
+            callback=callback,
+            errback=errback,
+        )

--- a/ns1/rest/views.py
+++ b/ns1/rest/views.py
@@ -1,0 +1,64 @@
+#
+# Copyright (c) 2014 NSONE, Inc.
+#
+# License under The MIT License (MIT). See LICENSE in project root.
+#
+
+from . import resource
+
+
+class Views(resource.BaseResource):
+
+    ROOT = "views"
+
+    BOOL_FIELDS = []
+    INT_FIELDS = ["preference"]
+    PASSTHRU_FIELDS = [
+        "read_acls",
+        "update_acls",
+        "zones",
+        "networks",
+    ]
+
+    def list(self, callback=None, errback=None):
+        return self._make_request(
+            "GET", "%s" % self.ROOT, callback=callback, errback=errback,
+        )
+
+    def retrieve(self, name, callback=None, errback=None):
+        return self._make_request(
+            "GET",
+            "%s/%s" % (self.ROOT, name),
+            callback=callback,
+            errback=errback,
+        )
+
+    def create(self, name, callback=None, errback=None, **kwargs):
+        body = {}
+        self._buildStdBody(body, kwargs)
+        return self._make_request(
+            "PUT",
+            "%s/%s" % (self.ROOT, name),
+            body=body,
+            callback=callback,
+            errback=errback,
+        )
+
+    def update(self, name, callback=None, errback=None, **kwargs):
+        body = {}
+        self._buildStdBody(body, kwargs)
+        return self._make_request(
+            "POST",
+            "%s/%s" % (self.ROOT, name),
+            body=body,
+            callback=callback,
+            errback=errback,
+        )
+
+    def delete(self, name, callback=None, errback=None):
+        return self._make_request(
+            "DELETE",
+            "%s/%s" % (self.ROOT, name),
+            callback=callback,
+            errback=errback,
+        )

--- a/tests/unit/test_acls.py
+++ b/tests/unit/test_acls.py
@@ -1,0 +1,101 @@
+import pytest
+
+import ns1.rest.acls
+
+try:  # Python 3.3 +
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+
+@pytest.fixture
+def client_config(config):
+    config.loadFromDict(
+        {
+            "endpoint": "api.nsone.net",
+            "default_key": "test1",
+            "keys": {
+                "test1": {
+                    "key": "key-1",
+                    "desc": "test key number 1",
+                    "writeLock": True,
+                }
+            },
+        }
+    )
+
+    return config
+
+
+cases = {
+    "basic list": (
+        "list",
+        ([], {}),
+        "GET",
+        "acls",
+        ([], {"callback": None, "errback": None}),
+    ),
+    "basic create": (
+        "create",
+        (
+            ["my-acl"],
+            {"src_prefixes": [], "tsig_keys": [], "gss_tsig_identities": []},
+        ),
+        "PUT",
+        "acls/my-acl",
+        (
+            [],
+            {
+                "body": {
+                    "src_prefixes": [],
+                    "tsig_keys": [],
+                    "gss_tsig_identities": [],
+                },
+                "callback": None,
+                "errback": None,
+            },
+        ),
+    ),
+    "basic retrieve": (
+        "retrieve",
+        (["my-acl"], {}),
+        "GET",
+        "acls/my-acl",
+        ([], {"callback": None, "errback": None}),
+    ),
+    "basic update": (
+        "update",
+        (["my-acl"], {"src_prefixes": ["prefix"]}),
+        "POST",
+        "acls/my-acl",
+        (
+            [],
+            {
+                "body": {"src_prefixes": ["prefix"]},
+                "callback": None,
+                "errback": None,
+            },
+        ),
+    ),
+    "basic delete": (
+        "delete",
+        (["my-acl"], {}),
+        "DELETE",
+        "acls/my-acl",
+        ([], {"callback": None, "errback": None}),
+    ),
+}
+
+
+def test_rest_acls_crud(client_config):
+    resource = ns1.rest.acls.ACLs(client_config)
+    resource._make_request = mock.MagicMock()
+
+    for name, test_case in cases.items():
+        resource._make_request.reset_mock()
+        func, in_args, method, route, out_args = test_case
+
+        getattr(resource, func)(*in_args[0], **in_args[1])
+        resource._make_request.assert_called_once_with(
+            method, route, *out_args[0], **out_args[1]
+        )

--- a/tests/unit/test_record.py
+++ b/tests/unit/test_record.py
@@ -1,0 +1,204 @@
+import pytest
+
+import ns1.rest.records
+
+from ns1.rest.errors import ResourceException
+
+try:  # Python 3.3 +
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+
+@pytest.fixture
+def records_config(config):
+    config.loadFromDict(
+        {
+            "endpoint": "api.nsone.net",
+            "default_key": "test1",
+            "keys": {
+                "test1": {
+                    "key": "key-1",
+                    "desc": "test key number 1",
+                    "writeLock": True,
+                }
+            },
+        }
+    )
+
+    return config
+
+
+def test_rest_record_retrieve(records_config):
+    r = ns1.rest.records.Records(records_config)
+    r._make_request = mock.MagicMock()
+
+    r.retrieve("example.com", "sub.example.com", "A")
+    r._make_request.assert_called_once_with(
+        "GET",
+        "zones/example.com/sub.example.com/A",
+        callback=None,
+        errback=None,
+    )
+
+    r._make_request.reset_mock()
+
+    r.retrieve("example-handle", "sub.example.com", "A")
+    r._make_request.assert_called_once_with(
+        "GET",
+        "zones/example-handle/sub.example.com/A",
+        callback=None,
+        errback=None,
+    )
+
+
+def test_rest_record_create(records_config):
+    r = ns1.rest.records.Records(records_config)
+    r._make_request = mock.MagicMock()
+
+    data = {"ttl": 999}
+    r.create("example.com", "sub.example.com", "A", **data)
+    r._make_request.assert_called_once_with(
+        "PUT",
+        "zones/example.com/sub.example.com/A",
+        body={
+            "zone_name": "example.com",
+            "zone": "example.com",
+            "domain": "sub.example.com",
+            "type": "A",
+            "ttl": 999,
+        },
+        callback=None,
+        errback=None,
+    )
+    r._make_request.reset_mock()
+
+    data = {"zone": "example.com", "ttl": 999}
+    r.create("example-name", "sub.example.com", "A", **data)
+    r._make_request.assert_called_once_with(
+        "PUT",
+        "zones/example-name/sub.example.com/A",
+        body={
+            "zone": "example.com",
+            "domain": "sub.example.com",
+            "type": "A",
+            "zone_name": "example-name",
+            "ttl": 999,
+        },
+        callback=None,
+        errback=None,
+    )
+
+
+def test_rest_record_update(records_config):
+    r = ns1.rest.records.Records(records_config)
+    r._make_request = mock.MagicMock()
+
+    data = {"ttl": 999}
+    r.update("example.com", "sub.example.com", "A", **data)
+    r._make_request.assert_called_once_with(
+        "POST",
+        "zones/example.com/sub.example.com/A",
+        body={
+            "zone_name": "example.com",
+            "domain": "sub.example.com",
+            "type": "A",
+            "ttl": 999,
+        },
+        callback=None,
+        errback=None,
+    )
+    r._make_request.reset_mock()
+
+    data = {"ttl": 999}
+    r.update("example-name", "sub.example.com", "A", **data)
+    r._make_request.assert_called_once_with(
+        "POST",
+        "zones/example-name/sub.example.com/A",
+        body={
+            "zone_name": "example-name",
+            "domain": "sub.example.com",
+            "type": "A",
+            "ttl": 999,
+        },
+        callback=None,
+        errback=None,
+    )
+    r._make_request.reset_mock()
+
+    data = {"zone": "example.com", "ttl": 999}
+    r.update("example-name", "sub.example.com", "A", **data)
+    r._make_request.assert_called_once_with(
+        "POST",
+        "zones/example-name/sub.example.com/A",
+        body={
+            "zone_name": "example-name",
+            "zone": "example.com",
+            "domain": "sub.example.com",
+            "type": "A",
+            "ttl": 999,
+        },
+        callback=None,
+        errback=None,
+    )
+    r._make_request.reset_mock()
+
+    data = {"zone_name": "example.com", "ttl": 999}
+    with pytest.raises(ResourceException) as ex:
+        r.update("example-name", "sub.example.com", "A", **data)
+    assert (
+        ex.value.message == "Passed names differ: example-name != example.com"
+    )
+    r._make_request.assert_not_called()
+
+
+def test_rest_record_delete(records_config):
+    r = ns1.rest.records.Records(records_config)
+    r._make_request = mock.MagicMock()
+
+    r.delete("example.com", "sub.example.com", "A")
+    r._make_request.assert_called_once_with(
+        "DELETE",
+        "zones/example.com/sub.example.com/A",
+        callback=None,
+        errback=None,
+    )
+
+    r._make_request.reset_mock()
+
+    r.delete("example-handle", "sub.example.com", "A")
+    r._make_request.assert_called_once_with(
+        "DELETE",
+        "zones/example-handle/sub.example.com/A",
+        callback=None,
+        errback=None,
+    )
+
+
+def test_rest_records_buildbody(records_config):
+    z = ns1.rest.records.Records(records_config)
+
+    kwargs = {"ttl": 900}
+    expected = {
+        "zone_name": "example.com",
+        "domain": "sub.example.com",
+        "type": "A",
+        "ttl": 900,
+    }
+    assert z._buildBody("example.com", "sub.example.com", "a", **kwargs) == (
+        "example.com",
+        expected,
+    )
+
+    kwargs = {"zone": "example.com", "ttl": 900}
+    expected = {
+        "zone_name": "example-name",
+        "zone": "example.com",
+        "domain": "sub.example.com",
+        "type": "A",
+        "ttl": 900,
+    }
+    assert z._buildBody("example-name", "sub.example.com", "a", **kwargs) == (
+        "example-name",
+        expected,
+    )

--- a/tests/unit/test_tsig.py
+++ b/tests/unit/test_tsig.py
@@ -1,0 +1,94 @@
+import pytest
+
+import ns1.rest.tsig
+
+try:  # Python 3.3 +
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+
+@pytest.fixture
+def client_config(config):
+    config.loadFromDict(
+        {
+            "endpoint": "api.nsone.net",
+            "default_key": "test1",
+            "keys": {
+                "test1": {
+                    "key": "key-1",
+                    "desc": "test key number 1",
+                    "writeLock": True,
+                }
+            },
+        }
+    )
+
+    return config
+
+
+cases = {
+    "basic list": (
+        "list",
+        ([], {}),
+        "GET",
+        "tsig",
+        ([], {"callback": None, "errback": None}),
+    ),
+    "basic create": (
+        "create",
+        (["my-tsig"], {"algorithm": "my-algorithm", "secret": "my-secret"}),
+        "PUT",
+        "tsig/my-tsig",
+        (
+            [],
+            {
+                "body": {"algorithm": "my-algorithm", "secret": "my-secret"},
+                "callback": None,
+                "errback": None,
+            },
+        ),
+    ),
+    "basic retrieve": (
+        "retrieve",
+        (["my-tsig"], {}),
+        "GET",
+        "tsig/my-tsig",
+        ([], {"callback": None, "errback": None}),
+    ),
+    "basic update": (
+        "update",
+        (["my-tsig"], {"secret": "new-secret"}),
+        "POST",
+        "tsig/my-tsig",
+        (
+            [],
+            {
+                "body": {"secret": "new-secret"},
+                "callback": None,
+                "errback": None,
+            },
+        ),
+    ),
+    "basic delete": (
+        "delete",
+        (["my-tsig"], {}),
+        "DELETE",
+        "tsig/my-tsig",
+        ([], {"callback": None, "errback": None}),
+    ),
+}
+
+
+def test_rest_tsig_crud(client_config):
+    resource = ns1.rest.tsig.TSIGs(client_config)
+    resource._make_request = mock.MagicMock()
+
+    for name, test_case in cases.items():
+        resource._make_request.reset_mock()
+        func, in_args, method, route, out_args = test_case
+
+        getattr(resource, func)(*in_args[0], **in_args[1])
+        resource._make_request.assert_called_once_with(
+            method, route, *out_args[0], **out_args[1]
+        )

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -1,0 +1,109 @@
+import pytest
+
+import ns1.rest.views
+
+try:  # Python 3.3 +
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+
+@pytest.fixture
+def client_config(config):
+    config.loadFromDict(
+        {
+            "endpoint": "api.nsone.net",
+            "default_key": "test1",
+            "keys": {
+                "test1": {
+                    "key": "key-1",
+                    "desc": "test key number 1",
+                    "writeLock": True,
+                }
+            },
+        }
+    )
+
+    return config
+
+
+cases = {
+    "basic list": (
+        "list",
+        ([], {}),
+        "GET",
+        "views",
+        ([], {"callback": None, "errback": None}),
+    ),
+    "basic create": (
+        "create",
+        (
+            ["my-view"],
+            {
+                "read_acls": [],
+                "update_acls": [],
+                "zones": [],
+                "networks": [],
+                "preference": 111,
+            },
+        ),
+        "PUT",
+        "views/my-view",
+        (
+            [],
+            {
+                "body": {
+                    "read_acls": [],
+                    "update_acls": [],
+                    "zones": [],
+                    "networks": [],
+                    "preference": 111,
+                },
+                "callback": None,
+                "errback": None,
+            },
+        ),
+    ),
+    "basic retrieve": (
+        "retrieve",
+        (["my-view"], {}),
+        "GET",
+        "views/my-view",
+        ([], {"callback": None, "errback": None}),
+    ),
+    "basic update": (
+        "update",
+        (["my-view"], {"zones": ["my-zone"]}),
+        "POST",
+        "views/my-view",
+        (
+            [],
+            {
+                "body": {"zones": ["my-zone"]},
+                "callback": None,
+                "errback": None,
+            },
+        ),
+    ),
+    "basic delete": (
+        "delete",
+        (["my-view"], {}),
+        "DELETE",
+        "views/my-view",
+        ([], {"callback": None, "errback": None}),
+    ),
+}
+
+
+def test_rest_views_crud(client_config):
+    resource = ns1.rest.views.Views(client_config)
+    resource._make_request = mock.MagicMock()
+
+    for name, test_case in cases.items():
+        resource._make_request.reset_mock()
+        func, in_args, method, route, out_args = test_case
+
+        getattr(resource, func)(*in_args[0], **in_args[1])
+        resource._make_request.assert_called_once_with(
+            method, route, *out_args[0], **out_args[1]
+        )

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -1,5 +1,8 @@
-import ns1.rest.zones
 import pytest
+
+import ns1.rest.zones
+
+from ns1.rest.errors import ResourceException
 
 try:  # Python 3.3 +
     import unittest.mock as mock
@@ -39,6 +42,66 @@ def test_rest_zone_list(zones_config):
     )
 
 
+def test_rest_zone_create(zones_config):
+    z = ns1.rest.zones.Zones(zones_config)
+    z._make_request = mock.MagicMock()
+
+    data = {"ttl": 999}
+    z.create("example.com", **data)
+    z._make_request.assert_called_once_with(
+        "PUT",
+        "zones/example.com",
+        body={"zone": "example.com", "name": "example.com", "ttl": 999},
+        callback=None,
+        errback=None,
+    )
+    z._make_request.reset_mock()
+
+    data = {"zone": "example.com", "ttl": 999}
+    z.create("example-name", **data)
+    z._make_request.assert_called_once_with(
+        "PUT",
+        "zones/example-name",
+        body={"zone": "example.com", "name": "example-name", "ttl": 999},
+        callback=None,
+        errback=None,
+    )
+    z._make_request.reset_mock()
+
+    # if "zone" is not specified when name differs, server will reject if
+    # the passed name isn't an FQDN
+    data = {"ttl": 999}
+    z.create("example-name", **data)
+    z._make_request.assert_called_once_with(
+        "PUT",
+        "zones/example-name",
+        body={"zone": "example-name", "name": "example-name", "ttl": 999},
+        callback=None,
+        errback=None,
+    )
+    z._make_request.reset_mock()
+
+    # mismatched name
+    data = {"name": "example.com", "ttl": 999}
+    with pytest.raises(ResourceException) as ex:
+        z.create("example-name", **data)
+    assert (
+        ex.value.message == "Passed names differ: example-name != example.com"
+    )
+    z._make_request.assert_not_called()
+
+    # API should reject, zone is not an FQDN
+    data = {"zone": "example-name", "ttl": 999}
+    z.create("example-name", **data)
+    z._make_request.assert_called_once_with(
+        "PUT",
+        "zones/example-name",
+        body={"zone": "example-name", "name": "example-name", "ttl": 999},
+        callback=None,
+        errback=None,
+    )
+
+
 @pytest.mark.parametrize("zone, url", [("test.zone", "zones/test.zone")])
 def test_rest_zone_retrieve(zones_config, zone, url):
     z = ns1.rest.zones.Zones(zones_config)
@@ -53,9 +116,105 @@ def test_rest_zone_retrieve(zones_config, zone, url):
     )
 
 
+def test_rest_zone_update(zones_config):
+    z = ns1.rest.zones.Zones(zones_config)
+    z._make_request = mock.MagicMock()
+
+    data = {"ttl": 999}
+    z.update("example.com", **data)
+    z._make_request.assert_called_once_with(
+        "POST",
+        "zones/example.com",
+        body={"name": "example.com", "ttl": 999},
+        callback=None,
+        errback=None,
+    )
+    z._make_request.reset_mock()
+
+    data = {"ttl": 999}
+    z.update("example-name", **data)
+    z._make_request.assert_called_once_with(
+        "POST",
+        "zones/example-name",
+        body={"name": "example-name", "ttl": 999},
+        callback=None,
+        errback=None,
+    )
+    z._make_request.reset_mock()
+
+    data = {"zone": "example.com", "ttl": 999}
+    z.update("example-name", **data)
+    z._make_request.assert_called_once_with(
+        "POST",
+        "zones/example-name",
+        body={"name": "example-name", "zone": "example.com", "ttl": 999},
+        callback=None,
+        errback=None,
+    )
+    z._make_request.reset_mock()
+
+    data = {"name": "example.com", "ttl": 999}
+    with pytest.raises(ResourceException) as ex:
+        z.update("example-name", **data)
+    assert (
+        ex.value.message == "Passed names differ: example-name != example.com"
+    )
+    z._make_request.assert_not_called()
+
+
 def test_rest_zone_buildbody(zones_config):
     z = ns1.rest.zones.Zones(zones_config)
-    zone = "test.zone"
+
     kwargs = {"retry": "0", "refresh": 0, "expiry": 0.0, "nx_ttl": "0"}
-    body = {"zone": zone, "retry": 0, "refresh": 0, "expiry": 0, "nx_ttl": 0}
-    assert z._buildBody(zone, **kwargs) == body
+    expected = {
+        "name": "example.com",
+        "retry": 0,
+        "refresh": 0,
+        "expiry": 0,
+        "nx_ttl": 0,
+    }
+    assert z._buildBody("example.com", **kwargs) == ("example.com", expected)
+
+    kwargs = {
+        "zone": "example.com",
+        "retry": "0",
+        "refresh": 0,
+        "expiry": 0.0,
+        "nx_ttl": "0",
+    }
+    expected = {
+        "zone": "example.com",
+        "name": "example-name",
+        "retry": 0,
+        "refresh": 0,
+        "expiry": 0,
+        "nx_ttl": 0,
+    }
+    assert z._buildBody("example-name", **kwargs) == ("example-name", expected)
+
+    kwargs = {
+        "name": "example-name",
+        "retry": "0",
+        "refresh": 0,
+        "expiry": 0.0,
+        "nx_ttl": "0",
+    }
+    with pytest.raises(ResourceException) as ex:
+        assert z._buildBody("example-foo", **kwargs) == (
+            "example-name",
+            expected,
+        )
+    assert (
+        ex.value.message == "Passed names differ: example-foo != example-name"
+    )
+
+    # Handling the missing 'zone' field is the responsibility of the calling
+    # method, as we have different requirements for create and update.
+    expected = {
+        "name": "example-name",
+        "retry": 0,
+        "refresh": 0,
+        "expiry": 0,
+        "nx_ttl": 0,
+    }
+    assert z._buildBody("example-name", **kwargs) == ("example-name", expected)


### PR DESCRIPTION
existing functionality
======================

changes to rest/zones and rest/records to support named zone and
stay compatible.
examples/dns-views-compatibility

TLDR:
* crud arg is always "name/zone_name"
  * consistent across the resource
  * main behavior change is that views users MUST pass 'zone' on
    create

new functionality
=================

new endpoints for acls, tsigs, and views
examples/dns-views