### PR TITLE
pytest v6 deprecations

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         # Ignore the line length rule because black will handle that
         # and flake8 doesn't allow long comment lines.
-        flake8 . --count --show-source --statistics --extend-ignore=E501
+        flake8 . --exclude=.tox --count --show-source --statistics --extend-ignore=E501
     - name: Lint with black
       run: |
         black . --check -l 79 --diff

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,10 @@ skip_missing_interpreters = True
 [testenv]
 deps=
      pytest
-     pytest-pep8
      pytest-cov
 
 commands=
-     py.test --ignore=build --pep8 -v --cov=ns1 --cov-report=term tests
+     py.test --ignore=build -v --cov=ns1 --cov-report=term tests
 
 [testenv:py27]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skip_missing_interpreters = True
 
 [testenv]
 deps=
+     mock
      pytest
      pytest-cov
 


### PR DESCRIPTION
new release of pytest makes some deprecation warnings into errors

we were getting one from the pytest-pep8 dependency

since we've set up linting via gh actions it seemed reasonable just to
ditch the dependency