### PR TITLE
Fixup compatibility with Python 3.10

### DIFF
--- a/ns1/rest/records.py
+++ b/ns1/rest/records.py
@@ -40,7 +40,7 @@ class Records(resource.BaseResource):
         if isinstance(answers, py_str):
             answers = [answers]
         # otherwise, we need an iterable
-        elif not isinstance(answers, collections.Iterable):
+        elif not isinstance(answers, collections.abc.Iterable):
             raise Exception("invalid answers format (must be str or iterable)")
         # at this point we have a list. loop through and build out the answer
         # entries depending on contents


### PR DESCRIPTION
collections.Iterable was moved to collections.abc.Iterable in Python 3.8
but compatibility was preserved. In Python 3.10, old path was removed.