### PR TITLE
fixing parameter typo for rest.ipam.reservations.list method

### DIFF
--- a/ns1/rest/ipam.py
+++ b/ns1/rest/ipam.py
@@ -502,7 +502,7 @@ class Reservations(resource.BaseResource):
     def list(self, scopegroup_id, callback=None, errback=None):
         return self._make_request(
             "GET",
-            "%s?scopeGroupId=%d" % (self.ROOT, int(scopegroup_id)),
+            "%s?scope_group_id=%d" % (self.ROOT, int(scopegroup_id)),
             callback=callback,
             errback=errback,
         )


### PR DESCRIPTION
changed parameter from scopeGroupId to scope_group_id to conform with API