### PR TITLE
Re-use connections with Session objects in RequestsTransport

### DIFF
--- a/ns1/rest/transport/requests.py
+++ b/ns1/rest/transport/requests.py
@@ -26,11 +26,12 @@ class RequestsTransport(TransportBase):
         if not have_requests:
             raise ImportError("requests module required for RequestsTransport")
         TransportBase.__init__(self, config, self.__module__)
+        self.session = requests.Session()
         self.REQ_MAP = {
-            "GET": requests.get,
-            "POST": requests.post,
-            "DELETE": requests.delete,
-            "PUT": requests.put,
+            "GET": self.session.get,
+            "POST": self.session.post,
+            "DELETE": self.session.delete,
+            "PUT": self.session.put,
         }
         self._timeout = self._config.get("timeout", None)
         if isinstance(self._timeout, list) and len(self._timeout) == 2:


### PR DESCRIPTION
From https://docs.python-requests.org/en/master/user/advanced/#session-objects:

> The Session object [...] will use urllib3’s connection pooling[1]. So if you’re making several requests to the same host, the underlying TCP connection will be reused, which can result in a significant performance increase (see HTTP persistent connection[2]).

[1] https://urllib3.readthedocs.io/en/latest/reference/index.html#module-urllib3.connectionpool
[2] https://en.wikipedia.org/wiki/HTTP_persistent_connection