### PR TITLE
Add release action on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Build distribution
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install build dependencies
+        run: python -m pip install build wheel
+
+      - name: Build distributions
+        shell: bash -l {0}
+        run: python setup.py sdist bdist_wheel
+
+      - name: Publish package to PyPI
+        if: github.repository == 'ns1/ns1-python' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.ns1_python_publish }}


### PR DESCRIPTION
This PR adds an action that pushes a package to PyPi when a commit is tagged with a version.

The packaging steps will happen on each push to ensure that the repo is in a package-able state.
Releases are published automatically when a tag is pushed to GitHub.

```
 # Create tags
 git commit --allow-empty -m "Release 1.2.3"
 git tag -a 1.2.3 -m "Version 1.2.3"

 # Push
 git push origin --tags
```