### PR TITLE
Add the ability to pass in params to search function

### DIFF
--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -87,8 +87,7 @@ class Zones(resource.BaseResource):
             pagination_handler=zone_retrieve_pagination,
         )
 
-    def search(self, zone, q=None, has_geo=False, callback=None, errback=None):
-        params = {}
+    def search(self, zone, q=None, has_geo=False, callback=None, errback=None, params={}):
         if q is not None:
             params["q"] = q
         if has_geo:

--- a/ns1/zones.py
+++ b/ns1/zones.py
@@ -65,14 +65,14 @@ class Zone(object):
             self.zone, callback=success, errback=errback
         )
 
-    def search(self, q=None, has_geo=False, callback=None, errback=None):
+    def search(self, q=None, has_geo=False, callback=None, errback=None, params={}):
         """
         Search within a zone for specific metadata. Zone must already be loaded.
         """
         if not self.data:
             raise ZoneException("zone not loaded")
 
-        return self._rest.search(self.zone, q, has_geo, callback, errback)
+        return self._rest.search(self.zone, q, has_geo, callback, errback, params)
 
     def delete(self, callback=None, errback=None):
         """


### PR DESCRIPTION
Add the ability to pass in params to search function, useful for changing the "max" param specifically. There is no current way to accomplish this per the SDK.

For example:
`p = {"max":100}`
`zone.search('test', False, None, None, p)`

