### PR TITLE
Fixes #92 #93 & #94

### DIFF
--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -566,11 +566,13 @@ class NS1:
         return scope.create(callback=callback, errback=errback, **kwargs)
 
     def loadScope(
-        self, scopegroup_id, address_id, callback=None, errback=None
-    ):
+            self,
+            id,
+            callback=None,
+            errback=None):
         import ns1.ipam
-
-        scope = ns1.ipam.Scope(self.config, scopegroup_id, address_id)
+        # pass dummy values for scope group and address id, as these are not used here anyways
+        scope = ns1.ipam.Scope(self.config, None, None, id)
 
         return scope.load(callback=callback, errback=errback)
 

--- a/ns1/ipam.py
+++ b/ns1/ipam.py
@@ -907,6 +907,7 @@ class Scope(object):
 
         def success(result, *args):
             self.data = result
+            self.scopegroup_id = result["scope_group_id"]
             self.address_id = result["address_id"]
             self.options = result["options"]
 

--- a/ns1/rest/ipam.py
+++ b/ns1/rest/ipam.py
@@ -11,12 +11,11 @@ class Addresses(resource.BaseResource):
     ROOT = "ipam/address"
     INT_FIELDS = [
         "network_id",
-        "address_id",
-        "root_address_id",
-        " merged_address_id",
+        "parent_id",
         "scope_group_id",
     ]
-    PASSTHRU_FIELDS = ["prefix", "status", "desc", "tags", "reserve"]
+    PASSTHRU_FIELDS = ["name", "prefix", "status", "desc", "tags", "reserve", "hostname", "forward_zone_handle",
+                       "reverse_zone_handle", ]
     BOOL_FIELDS = ["parent"]
 
     def _buildBody(self, **kwargs):
@@ -137,12 +136,15 @@ class Addresses(resource.BaseResource):
     #                               callback=callback,
     #                               errback=errback)
 
-    def search(self, network_id, prefix, callback=None, errback=None):
+    def search(self, callback=None, errback=None, **kwargs):
+        params = {k: v for k, v in kwargs if
+                  k in ['network_id', 'asc_desc', 'mask', 'max', 'name', 'order_by', 'prefix', 'tag', 'status']}
         return self._make_request(
             "GET",
-            "%s/search/%s/%s" % (self.ROOT, network_id, prefix),
+            "%s/search" % (self.ROOT),
             callback=callback,
             errback=errback,
+            params=params,
         )
 
 
@@ -218,7 +220,7 @@ class Networks(resource.BaseResource):
 class Scopegroups(resource.BaseResource):
     ROOT = "dhcp/scopegroup"
     INT_FIELDS = ["id", "dhcp_service_id", "valid_lifetime_secs"]
-    PASSTHRU_FIELDS = ["dhcpv4", "dhcpv6", "name", "tags"]
+    PASSTHRU_FIELDS = ["dhcpv4", "dhcpv6", "name", "tags", "template", "options", ]
     BOOL_FIELDS = ["enabled", "echo_client_id"]
 
     def _buildBody(self, **kwargs):
@@ -267,6 +269,15 @@ class Scopegroups(resource.BaseResource):
             "%s/%s" % (self.ROOT, scope_group_id),
             callback=callback,
             errback=errback,
+        )
+
+    def expand(self, scope_group_id, callback=None, errback=None):
+        return self._make_request(
+            "GET",
+            "%s/%s" % (self.ROOT, scope_group_id),
+            callback=callback,
+            errback=errback,
+            params={'expand': True}
         )
 
 


### PR DESCRIPTION
Fix loadScope so it accepts only the required scope id
Fix rest.ipam.xyz classes so they accept the fields listed on the current API docs
Fix rest.ipam.addresses.search so it works pr API docs
Add expand method to rest.ipam.scopegroups

Running tests in 3.9 fails helpers::test_singleton_mixin_with_concurrency but I doubt this is my doing..