### PR TITLE
MIT-146: added ACL routes

### DIFF
--- a/ns1/acls.py
+++ b/ns1/acls.py
@@ -1,0 +1,76 @@
+#
+# Copyright (c) 2014 NSONE, Inc.
+#
+# License under The MIT License (MIT). See LICENSE in project root.
+#
+from ns1.rest.acls import Acls
+
+
+class AclException(Exception):
+    pass
+
+
+class Acl(object):
+
+    def __init__(self, config, acl):
+        self._rest = Acls(config)
+        self.config = config
+        self.acl = acl
+        self.data = None
+
+    def __repr__(self):
+        return "<Acl acl=%s>" % self.acl
+
+    def __getitem__(self, item):
+        return self.data.get(item, None)
+
+    def reload(self, callback=None, errback=None):
+        return self.load(reload=True, callback=callback, errback=errback)
+
+    def load(self, callback=None, errback=None, reload=False):
+        if not reload and self.data:
+            raise AclException("acl already loaded")
+
+        def success(result, *args):
+            self.data = result
+            if callback:
+                return callback(self)
+            else:
+                return self
+
+        return self._rest.retrieve(
+            self.acl, callback=success, errback=errback
+        )
+
+    def delete(self, callback=None, errback=None):
+        return self._rest.delete(self.acl, callback=callback, errback=errback)
+
+    def update(self, callback=None, errback=None, **kwargs):
+        if not self.data:
+            raise AclException("acl not loaded")
+
+        def success(result, *args):
+            self.data = result
+            if callback:
+                return callback(self)
+            else:
+                return self
+
+        return self._rest.update(
+            self.acl, callback=success, errback=errback, **kwargs
+        )
+
+    def create(self, callback=None, errback=None, **kwargs):
+        if self.data:
+            raise AclException("acl already loaded")
+
+        def success(result, *args):
+            self.data = result
+            if callback:
+                return callback(self)
+            else:
+                return self
+
+        return self._rest.create(
+            self.acl, callback=success, errback=errback, **kwargs
+        )

--- a/ns1/rest/acls.py
+++ b/ns1/rest/acls.py
@@ -1,0 +1,75 @@
+#
+# Copyright (c) 2014 NSONE, Inc.
+#
+# License under The MIT License (MIT). See LICENSE in project root.
+
+from . import resource
+
+
+class Acls(resource.BaseResource):
+
+    ROOT = "acls"
+    PASSTHRU_FIELDS = [
+        "src_prefixes",
+        "tsig_keys",
+        "gss_tsig_identities"
+    ]
+
+    def _buildBody(self, acl_name, **kwargs):
+        body = {}
+        body["acl_name"] = acl_name
+        self._buildStdBody(body, kwargs)
+        return body
+
+    def create(
+        self, acl_name, callback=None, errback=None, **kwargs
+    ):
+        body = self._buildBody(acl_name, **kwargs)
+
+        return self.create_raw(
+            acl_name,
+            body,
+            callback=callback,
+            errback=errback,
+            **kwargs
+        )
+
+    def create_raw(
+        self, acl_name, body, callback=None, errback=None, **kwargs
+    ):
+        return self._make_request(
+            "PUT",
+            "%s/%s" % (self.ROOT, acl_name),
+            body=body,
+            callback=callback,
+            errback=errback,
+        )
+
+    def update(
+        self, acl_name, callback=None, errback=None, **kwargs
+    ):
+        body = self._buildBody(acl_name, **kwargs)
+
+        return self._make_request(
+            "POST",
+            "%s/%s" % (self.ROOT, acl_name),
+            body=body,
+            callback=callback,
+            errback=errback,
+        )
+
+    def delete(self, acl_name, callback=None, errback=None):
+        return self._make_request(
+            "DELETE",
+            "%s/%s" % (self.ROOT, acl_name),
+            callback=callback,
+            errback=errback,
+        )
+
+    def retrieve(self, acl_name, callback=None, errback=None):
+        return self._make_request(
+            "GET",
+            "%s/%s" % (self.ROOT, acl_name),
+            callback=callback,
+            errback=errback,
+        )

--- a/tests/unit/test_acl.py
+++ b/tests/unit/test_acl.py
@@ -1,0 +1,90 @@
+import pytest
+
+import ns1.rest.acls
+
+try:  # Python 3.3 +
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+
+@pytest.fixture
+def acl_config(config):
+    config.loadFromDict(
+        {
+            "endpoint": "api.nsone.net",
+            "default_key": "test1",
+            "keys": {
+                "test1": {
+                    "key": "key-1",
+                    "desc": "test key number 1",
+                    "writeLock": True,
+                }
+            },
+        }
+    )
+    return config
+
+
+@pytest.mark.parametrize("acl_name, url", [("test_acl", "acls/test_acl")])
+def test_rest_acl_retrieve(acl_config, acl_name, url):
+    z = ns1.rest.acls.Acls(acl_config)
+    z._make_request = mock.MagicMock()
+    z.retrieve(acl_name)
+    z._make_request.assert_called_once_with(
+        "GET", url, callback=None, errback=None
+    )
+
+
+@pytest.mark.parametrize(
+    "acl_name, url",
+    [(
+        "test_acl",
+        "acls/test_acl",
+    )],
+)
+def test_rest_acl_create(
+    acl_config, acl_name, url
+):
+    z = ns1.rest.acls.Acls(acl_config)
+    z._make_request = mock.MagicMock()
+    z.create(acl_name=acl_name)
+    z._make_request.assert_called_once_with(
+        "PUT",
+        url,
+        body={
+            "acl_name": acl_name,
+        },
+        callback=None,
+        errback=None,
+        
+    )
+
+
+@pytest.mark.parametrize(
+    "acl_name, url",
+    [("test_acl", "acls/test_acl")],
+)
+def test_rest_acl_update(
+    acl_config, acl_name, url
+):
+    z = ns1.rest.acls.Acls(acl_config)
+    z._make_request = mock.MagicMock()
+    z.update(acl_name=acl_name)
+    z._make_request.assert_called_once_with(
+        "POST",
+        url,
+        callback=None,
+        errback=None,
+        body={"acl_name": acl_name},
+    )
+
+
+@pytest.mark.parametrize("acl_name, url", [("test_acl", "acls/test_acl")])
+def test_rest_acl_delete(acl_config, acl_name, url):
+    z = ns1.rest.acls.Acls(acl_config)
+    z._make_request = mock.MagicMock()
+    z.delete(acl_name)
+    z._make_request.assert_called_once_with(
+        "DELETE", url, callback=None, errback=None
+    )


### PR DESCRIPTION
Added access control lists routes according to [documentation](https://ns1.com/api?docId=204987).