### PR TITLE
Passthrough tags and primary_master fields for zones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ doc/_build/
 
 # PyBuilder
 target/
+
+# Virtual environments
+venv/

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -20,7 +20,7 @@ class Zones(resource.BaseResource):
         "networks",
         "link",
         "primary_master",
-        "tags"
+        "tags",
     ]
     BOOL_FIELDS = ["dnssec"]
 

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -19,6 +19,8 @@ class Zones(resource.BaseResource):
         "meta",
         "networks",
         "link",
+        "primary_master",
+        "tags"
     ]
     BOOL_FIELDS = ["dnssec"]
 

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -56,6 +56,6 @@ def test_rest_zone_retrieve(zones_config, zone, url):
 def test_rest_zone_buildbody(zones_config):
     z = ns1.rest.zones.Zones(zones_config)
     zone = "test.zone"
-    kwargs = {"retry": "0", "refresh": 0, "expiry": 0.0, "nx_ttl": "0"}
-    body = {"zone": zone, "retry": 0, "refresh": 0, "expiry": 0, "nx_ttl": 0}
+    kwargs = {"retry": "0", "refresh": 0, "expiry": 0.0, "nx_ttl": "0", "primary_master": "a.b.c.com", "tags": {"foo": "bar", "hai": "bai"}}
+    body = {"zone": zone, "retry": 0, "refresh": 0, "expiry": 0, "nx_ttl": 0, "primary_master": "a.b.c.com", "tags": {"foo": "bar", "hai": "bai"}}
     assert z._buildBody(zone, **kwargs) == body

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -57,20 +57,20 @@ def test_rest_zone_buildbody(zones_config):
     z = ns1.rest.zones.Zones(zones_config)
     zone = "test.zone"
     kwargs = {
-        "retry": "0", 
-        "refresh": 0, 
-        "expiry": 0.0, 
-        "nx_ttl": "0", 
-        "primary_master": "a.b.c.com", 
+        "retry": "0",
+        "refresh": 0,
+        "expiry": 0.0,
+        "nx_ttl": "0",
+        "primary_master": "a.b.c.com",
         "tags": {"foo": "bar", "hai": "bai"}
     }
     body = {
-        "zone": zone, 
-        "retry": 0, 
-        "refresh": 0, 
-        "expiry": 0, 
-        "nx_ttl": 0, 
-        "primary_master": "a.b.c.com", 
+        "zone": zone,
+        "retry": 0,
+        "refresh": 0,
+        "expiry": 0,
+        "nx_ttl": 0,
+        "primary_master": "a.b.c.com",
         "tags": {"foo": "bar", "hai": "bai"}
     }
     assert z._buildBody(zone, **kwargs) == body

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -62,7 +62,7 @@ def test_rest_zone_buildbody(zones_config):
         "expiry": 0.0,
         "nx_ttl": "0",
         "primary_master": "a.b.c.com",
-        "tags": {"foo": "bar", "hai": "bai"}
+        "tags": {"foo": "bar", "hai": "bai"},
     }
     body = {
         "zone": zone,
@@ -71,6 +71,6 @@ def test_rest_zone_buildbody(zones_config):
         "expiry": 0,
         "nx_ttl": 0,
         "primary_master": "a.b.c.com",
-        "tags": {"foo": "bar", "hai": "bai"}
+        "tags": {"foo": "bar", "hai": "bai"},
     }
     assert z._buildBody(zone, **kwargs) == body

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -56,6 +56,21 @@ def test_rest_zone_retrieve(zones_config, zone, url):
 def test_rest_zone_buildbody(zones_config):
     z = ns1.rest.zones.Zones(zones_config)
     zone = "test.zone"
-    kwargs = {"retry": "0", "refresh": 0, "expiry": 0.0, "nx_ttl": "0", "primary_master": "a.b.c.com", "tags": {"foo": "bar", "hai": "bai"}}
-    body = {"zone": zone, "retry": 0, "refresh": 0, "expiry": 0, "nx_ttl": 0, "primary_master": "a.b.c.com", "tags": {"foo": "bar", "hai": "bai"}}
+    kwargs = {
+        "retry": "0", 
+        "refresh": 0, 
+        "expiry": 0.0, 
+        "nx_ttl": "0", 
+        "primary_master": "a.b.c.com", 
+        "tags": {"foo": "bar", "hai": "bai"}
+    }
+    body = {
+        "zone": zone, 
+        "retry": 0, 
+        "refresh": 0, 
+        "expiry": 0, 
+        "nx_ttl": 0, 
+        "primary_master": "a.b.c.com", 
+        "tags": {"foo": "bar", "hai": "bai"}
+    }
     assert z._buildBody(zone, **kwargs) == body


### PR DESCRIPTION
Currently, the `primary_master` and `tags` fields are not passed to the body of the API call when creating and updating zones.