### PR TITLE
Added stats usage pagination support

### DIFF
--- a/ns1/rest/stats.py
+++ b/ns1/rest/stats.py
@@ -59,7 +59,14 @@ class Stats(resource.BaseResource):
 
         return self._make_request(
             "GET",
-            "%s?%s" % (url, urlencode(args)),
+            url + ('?' + urlencode(args) if args else ''),
             callback=callback,
             errback=errback,
+            pagination_handler=stats_usage_pagination,
         )
+
+
+# successive pages just extend the usage list
+def stats_usage_pagination(curr_json, next_json):
+    curr_json.extend(next_json)
+    return curr_json

--- a/tests/unit/test_stats.py
+++ b/tests/unit/test_stats.py
@@ -44,3 +44,27 @@ def test_qps(stats_config, value, expected):
     s._make_request.assert_called_once_with(
         "GET", expected, callback=None, errback=None
     )
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    (
+        ({}, "stats/usage"),
+        (
+            {"zone": "test.com", "domain": "foo", "type": "A"},
+            "stats/usage/test.com/foo/A",
+        ),
+        ({"zone": "test.com"}, "stats/usage/test.com"),
+    ),
+)
+def test_usage(stats_config, value, expected):
+    s = ns1.rest.stats.Stats(stats_config)
+    s._make_request = mock.MagicMock()
+    s.usage(**value)
+    s._make_request.assert_called_once_with(
+        "GET",
+        expected,
+        callback=None,
+        errback=None,
+        pagination_handler=ns1.rest.stats.stats_usage_pagination,
+    )


### PR DESCRIPTION
We have had some problems retrieving DNS usage because of pagination. This happened when we passed the 1000 records because of the limitations 