### PR TITLE
Drop outdated python 3.6, add support for python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ sudo: false
 language: python
 python:
   - '2.7'
-  - '3.6'
+  - '3.7'
+  - '3.8'
+  - '3.9'
+  - '3.10'
 install:
   - pip install tox-travis Sphinx
 script:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ interface for managing zones, records, data feeds, and more.
 It supports synchronous and asynchronous transports.
 
 Both python 2.7 and 3.3+ are supported. Automated tests are currently run
-against 2.7 and 3.6.
+against 2.7, 3.7, 3.8, 3.9 and 3.10.
 
 Installation
 ============

--- a/ns1/rest/records.py
+++ b/ns1/rest/records.py
@@ -2,7 +2,10 @@
 # Copyright (c) 2014 NSONE, Inc.
 #
 # License under The MIT License (MIT). See LICENSE in project root.
-import collections
+try:
+    from collections.abc import Iterable
+except:
+    from collections import Iterable
 import sys
 
 from . import resource
@@ -40,7 +43,7 @@ class Records(resource.BaseResource):
         if isinstance(answers, py_str):
             answers = [answers]
         # otherwise, we need an iterable
-        elif not isinstance(answers, collections.Iterable):
+        elif not isinstance(answers, Iterable):
             raise Exception("invalid answers format (must be str or iterable)")
         # at this point we have a list. loop through and build out the answer
         # entries depending on contents

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33
+envlist = py27,py37,py38,py39,py310
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Added support for python 3.10 (changed to collections.abc.Iterable) with fallback for legacy 2.7.
Dropped 3.6 since it reached EOL as per https://devguide.python.org/versions/

@ross FYI - this affects octodns_ns1 when using python 3.10.