### PR TITLE
clarify API key examples

### DIFF
--- a/doc/api/config.rst
+++ b/doc/api/config.rst
@@ -13,12 +13,12 @@ Sample:
        "verbosity": 5,
        "keys": {
             "account1": {
-                "key": "qACMD09OJXBxT7XOuRs8",
+                "key": "<<CLEARTEXT API KEY>>",
                 "desc": "account number 1",
                 "writeLock": true
             },
             "account2": {
-                "key": "qACMD09OJXBxT7XOwv9v",
+                "key": "<<ANOTHER CLEARTEXT API KEY>>",
                 "desc": "account number 2",
                 "writeLock": false
             }

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -23,7 +23,7 @@ From an API Key
 .. code-block:: python
 
     # to generate a configuration based on an api key
-    api = NS1(apiKey='qACMD09OJXBxT7XOuRs8')
+    api = NS1(apiKey='<<CLEARTEXT API KEY>>')
 
 JSON File Format
 ----------------
@@ -37,12 +37,12 @@ This example shows two different API keys. Which to use can be selected at runti
        "verbosity": 5,
        "keys": {
             "account1": {
-                "key": "qACMD09OJXBxT7XOuRs8",
+                "key": "<<CLEARTEXT API KEY>>",
                 "desc": "account number 1",
                 "writeLock": true
             },
             "account2": {
-                "key": "qACMD09OJXBxT7XOwv9v",
+                "key": "<<ANOTHER CLEARTEXT API KEY>>",
                 "desc": "account number 2",
                 "writeLock": false
             },

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -34,7 +34,7 @@ Simple example:
 
     from ns1 import NS1
 
-    api = NS1(apiKey='qACMD09OJXBxT7XOuRs8')
+    api = NS1(apiKey='<<CLEARTEXT API KEY>>')
     zone = api.createZone('example.com', nx_ttl=3600)
     print(zone)
     record = zone.add_A('honey', ['1.2.3.4', '5.6.7.8'])

--- a/examples/async-twisted.py
+++ b/examples/async-twisted.py
@@ -15,7 +15,7 @@ config = Config()
 # load default config
 config.loadFromFile(Config.DEFAULT_CONFIG_FILE)
 # to load directly from apikey instead, use
-# config.createFromAPIKey('qACMD09OJXBxT7XOuRs8')
+# config.createFromAPIKey('<<CLEARTEXT API KEY>>')
 
 # override default synchronous transport. note, this would normally go
 # in config file.

--- a/examples/clone-record.py
+++ b/examples/clone-record.py
@@ -10,7 +10,7 @@ from ns1 import NS1
 api = NS1()
 
 # to specify an apikey here instead, use:
-# api = NS1(apiKey='qACMD09OJXBxT7XOuRs8')
+# api = NS1(apiKey='<<CLEARTEXT API KEY>>')
 
 # to load an alternate configuration file:
 # api = NS1(configFile='/etc/ns1/api.json')

--- a/examples/config.py
+++ b/examples/config.py
@@ -13,7 +13,7 @@ from ns1 import NS1, Config
 api = NS1()
 
 # to specify an apikey here instead, use:
-api = NS1(apiKey="qACMD09OJXBxT7XOuRs8")
+api = NS1(apiKey="<<CLEARTEXT API KEY>>")
 
 # to load an alternate configuration file:
 api = NS1(configFile="/etc/ns1/api.json")
@@ -26,7 +26,7 @@ api = NS1(keyID="all-access")
 # if you have special needs, build your own Config object and pass it to
 # NS1:
 config = Config()
-config.createFromAPIKey("qACMD09OJXBxT7XOwv9v")
+config.createFromAPIKey("<<CLEARTEXT API KEY>>")
 config["verbosity"] = 5
 config["transport"] = "twisted"
 api = NS1(config=config)

--- a/examples/data.py
+++ b/examples/data.py
@@ -13,7 +13,7 @@ api = NS1()
 
 # from ns1 import Config
 # config = Config()
-# config.createFromAPIKey('qACMD09OJXBxT7XOuRs8')
+# config.createFromAPIKey('<<CLEARTEXT API KEY>>')
 # api = NS1(config=config)
 
 # create a zone to play in

--- a/examples/errors-and-debugging.py
+++ b/examples/errors-and-debugging.py
@@ -11,7 +11,7 @@ from ns1 import NS1, Config
 # the standard python logging system
 
 config = Config()
-config.createFromAPIKey("qACMD09OJXBxT7XOwv9v")
+config.createFromAPIKey("<<CLEARTEXT API KEY>>")
 config["verbosity"] = 5
 logging.basicConfig(level=logging.DEBUG)
 print(config)

--- a/examples/rate-limiting.py
+++ b/examples/rate-limiting.py
@@ -59,7 +59,7 @@ def _get_config():
     # load default config
     config.loadFromFile(Config.DEFAULT_CONFIG_FILE)
     # to load directly from apikey instead, use
-    # config.createFromAPIKey('qACMD09OJXBxT7XOuRs8')
+    # config.createFromAPIKey('<<CLEARTEXT API KEY>>')
 
     return config
 

--- a/examples/stats.py
+++ b/examples/stats.py
@@ -10,7 +10,7 @@ from ns1 import NS1
 api = NS1()
 
 # to specify an apikey here instead, use:
-# api = NS1(apiKey='qACMD09OJXBxT7XOuRs8')
+# api = NS1(apiKey='<<CLEARTEXT API KEY>>')
 
 # to load an alternate configuration file:
 # api = NS1(configFile='/etc/ns1/api.json')

--- a/examples/team.py
+++ b/examples/team.py
@@ -11,7 +11,7 @@ from ns1 import NS1
 api = NS1()
 
 # to specify an apikey here instead, use:
-# api = NS1(apiKey='qACMD09OJXBxT7XOuRs8')
+# api = NS1(apiKey='<<CLEARTEXT API KEY>>')
 
 # to load an alternate configuration file:
 # api = NS1(configFile='/etc/ns1/api.json')

--- a/examples/zone-import.py
+++ b/examples/zone-import.py
@@ -10,7 +10,7 @@ from ns1 import NS1
 api = NS1()
 
 # to specify an apikey here instead, use:
-# api = NS1(apiKey='qACMD09OJXBxT7XOuRs8')
+# api = NS1(apiKey='<<CLEARTEXT API KEY>>')
 
 # to load an alternate configuration file:
 # api = NS1(configFile='/etc/ns1/api.json')

--- a/examples/zones.py
+++ b/examples/zones.py
@@ -10,7 +10,7 @@ from ns1 import NS1
 api = NS1()
 
 # to specify an apikey here instead, use:
-# api = NS1(apiKey='qACMD09OJXBxT7XOuRs8')
+# api = NS1(apiKey='<<CLEARTEXT API KEY>>')
 
 # to load an alternate configuration file:
 # api = NS1(configFile='/etc/ns1/api.json')


### PR DESCRIPTION
Make it more apparent that the API keys in our examples are not real API keys.