### PR TITLE
Deprecate "writeLocked" keys, which do not actually do anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 * Drop support for EOL Python 2.7 and 3.7. Add support for Python 3.11
   and 3.12.
+* Deprecate "writeLocked" keys, which did not actually do anything.
 
 ## 0.18.0 (August 23, 2022)
 * Add usage stats pagination support

--- a/doc/api/config.rst
+++ b/doc/api/config.rst
@@ -15,12 +15,10 @@ Sample:
             "account1": {
                 "key": "<<CLEARTEXT API KEY>>",
                 "desc": "account number 1",
-                "writeLock": true
             },
             "account2": {
                 "key": "<<ANOTHER CLEARTEXT API KEY>>",
                 "desc": "account number 2",
-                "writeLock": false
             }
        },
        "cli": {

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -39,12 +39,10 @@ This example shows two different API keys. Which to use can be selected at runti
             "account1": {
                 "key": "<<CLEARTEXT API KEY>>",
                 "desc": "account number 1",
-                "writeLock": true
             },
             "account2": {
                 "key": "<<ANOTHER CLEARTEXT API KEY>>",
                 "desc": "account number 2",
-                "writeLock": false
             },
        },
        "cli": {

--- a/ns1/config.py
+++ b/ns1/config.py
@@ -10,6 +10,7 @@ try:
     from warnings import deprecated
 except ImportError:
     import warnings
+
     def deprecated(reason="deprecated"):
         def decorator(func):
             def wrapper_func():

--- a/ns1/config.py
+++ b/ns1/config.py
@@ -6,6 +6,18 @@
 import json
 import os
 
+try:
+    from warnings import deprecated
+except ImportError:
+    import warnings
+    def deprecated(reason="deprecated"):
+        def decorator(func):
+            def wrapper_func():
+                warnings.warn(reason, DeprecationWarning)
+                func()
+            return wrapper_func
+        return deprecated
+
 from ns1.rest.rate_limiting import default_rate_limit_func
 from ns1.rest.rate_limiting import rate_limit_strategy_concurrent
 from ns1.rest.rate_limiting import rate_limit_strategy_solo
@@ -181,7 +193,7 @@ class Config:
 
         return self._data["keys"][k]
 
-    @warning.deprecated("write locked keys are not implemented")
+    @deprecated("write locked keys are not implemented")
     def isKeyWriteLocked(self, keyID=None):
         """
         Determine if a key config is write locked.

--- a/ns1/config.py
+++ b/ns1/config.py
@@ -181,6 +181,7 @@ class Config:
 
         return self._data["keys"][k]
 
+    @warning.deprecated("write locked keys are not implemented")
     def isKeyWriteLocked(self, keyID=None):
         """
         Determine if a key config is write locked.

--- a/tests/unit/test_acl.py
+++ b/tests/unit/test_acl.py
@@ -18,7 +18,6 @@ def acl_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_address.py
+++ b/tests/unit/test_address.py
@@ -18,7 +18,6 @@ def address_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_apikey.py
+++ b/tests/unit/test_apikey.py
@@ -18,7 +18,6 @@ def apikey_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_client_classes.py
+++ b/tests/unit/test_client_classes.py
@@ -18,7 +18,6 @@ def client_class_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -29,7 +29,6 @@ def test_writeread(tmpdir, config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }
@@ -44,7 +43,6 @@ def test_writeread(tmpdir, config):
     assert cfg_read is not config
     assert cfg_read.getEndpoint() == config.getEndpoint()
     assert cfg_read.getCurrentKeyID() == config.getCurrentKeyID()
-    assert cfg_read.isKeyWriteLocked() == config.isKeyWriteLocked()
 
 
 def test_str_repr(config):
@@ -61,37 +59,11 @@ def test_dodefaults(config):
     assert config._data == defaults
 
 
-def test_apikey_writelock(config):
-    key_cfg = {
-        "default_key": "readonly",
-        "keys": {
-            "readonly": {
-                "key": "key-1",
-                "desc": "test key number 1",
-                "writeLock": True,
-            },
-            "readwrite": {
-                "key": "key-2",
-                "desc": "test key number 2",
-                "writeLock": False,
-            },
-        },
-    }
-
-    config.loadFromString(json.dumps(key_cfg))
-    assert config.getCurrentKeyID() == "readonly"
-    assert config.isKeyWriteLocked()
-
-    config.useKeyID("readwrite")
-    assert not config.isKeyWriteLocked()
-
-
 def test_create_from_apikey(config):
     apikey = "apikey"
     config.createFromAPIKey(apikey)
     assert config.getAPIKey() == apikey
     assert config.getCurrentKeyID() == "default"
-    assert not config.isKeyWriteLocked()
 
 
 def test_load_from_str(config):
@@ -101,7 +73,6 @@ def test_load_from_str(config):
             "test1": {
                 "key": "key-1",
                 "desc": "test key number 1",
-                "writeLock": True,
             }
         },
     }

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -18,7 +18,6 @@ def source_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_dhcp_option_spaces.py
+++ b/tests/unit/test_dhcp_option_spaces.py
@@ -18,7 +18,6 @@ def dhcp_option_space_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -30,7 +30,6 @@ def ns1_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_ipam.py
+++ b/tests/unit/test_ipam.py
@@ -18,7 +18,6 @@ def reservation_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -17,7 +17,6 @@ def monitoring_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -18,7 +18,6 @@ def network_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_pools.py
+++ b/tests/unit/test_pools.py
@@ -18,7 +18,6 @@ def pool_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_reservation.py
+++ b/tests/unit/test_reservation.py
@@ -26,7 +26,6 @@ def reservation_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_scope.py
+++ b/tests/unit/test_scope.py
@@ -26,7 +26,6 @@ def scope_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_scope_group.py
+++ b/tests/unit/test_scope_group.py
@@ -18,7 +18,6 @@ def scope_group_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_stats.py
+++ b/tests/unit/test_stats.py
@@ -17,7 +17,6 @@ def stats_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_team.py
+++ b/tests/unit/test_team.py
@@ -18,7 +18,6 @@ def team_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_tsig.py
+++ b/tests/unit/test_tsig.py
@@ -18,7 +18,6 @@ def tsig_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -18,7 +18,6 @@ def user_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -18,7 +18,6 @@ def view_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -17,7 +17,6 @@ def zones_config(config):
                 "test1": {
                     "key": "key-1",
                     "desc": "test key number 1",
-                    "writeLock": True,
                 }
             },
         }


### PR DESCRIPTION
We have a method which returns whether a key is write-locked. However, this is not documented and there is not any code to actually do anything with this. Lets mark the method as deprecated, remove the string from the examples and documentation. Some time in the future we can remove it.

FYI, marking things as deprecated: https://peps.python.org/pep-0702/

AFAICT to work with older versions of Python which do not include the `@warnings.deprecated` decorator we have to add our own.