### PR TITLE
Fix flake8 issues

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         # Ignore the line length rule because black will handle that
         # and flake8 doesn't allow long comment lines.
-        flake8 . --exclude=.tox --count --show-source --statistics --extend-ignore=E501
+        flake8 . --exclude=.tox --exclude=.eggs --count --show-source --statistics --extend-ignore=E501
     - name: Lint with black
       run: |
         black . --check -l 79 --diff

--- a/ns1/rest/records.py
+++ b/ns1/rest/records.py
@@ -4,7 +4,7 @@
 # License under The MIT License (MIT). See LICENSE in project root.
 try:
     from collections.abc import Iterable
-except:
+except ImportError:
     from collections import Iterable
 import sys
 

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -176,6 +176,7 @@ class Zones(resource.BaseResource):
             errback=errback,
         )
 
+
 # successive pages just extend the list of zones
 def zone_list_pagination(curr_json, next_json):
     curr_json.extend(next_json)

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -108,6 +108,7 @@ def test_rest_zone_version_delete(zones_config, zone, id, url):
         errback=None
     )
 
+
 def test_rest_zone_buildbody(zones_config):
     z = ns1.rest.zones.Zones(zones_config)
     zone = "test.zone"


### PR DESCRIPTION
This PR should fix the `flake8`-reported issues with the code, which will help clean-up the pipeline (although the `black` check will need to be removed of the code formatted to pass.)