### PR TITLE
Format code using "black" formatter

### DIFF
--- a/ns1/config.py
+++ b/ns1/config.py
@@ -16,8 +16,11 @@ except ImportError:
             def wrapper_func():
                 warnings.warn(reason, DeprecationWarning)
                 func()
+
             return wrapper_func
+
         return deprecated
+
 
 from ns1.rest.rate_limiting import default_rate_limit_func
 from ns1.rest.rate_limiting import rate_limit_strategy_concurrent

--- a/ns1/rest/account.py
+++ b/ns1/rest/account.py
@@ -7,7 +7,6 @@ from . import resource
 
 
 class Plan(resource.BaseResource):
-
     ROOT = "account/plan"
     PASSTHRU_FIELDS = ["type", "period", "notes"]
 

--- a/ns1/rest/acls.py
+++ b/ns1/rest/acls.py
@@ -7,7 +7,6 @@ from . import resource
 
 
 class Acls(resource.BaseResource):
-
     ROOT = "acls"
     PASSTHRU_FIELDS = ["src_prefixes", "tsig_keys", "gss_tsig_identities"]
 

--- a/ns1/rest/apikey.py
+++ b/ns1/rest/apikey.py
@@ -8,7 +8,6 @@ from . import resource
 
 
 class APIKey(resource.BaseResource):
-
     ROOT = "account/apikeys"
     PASSTHRU_FIELDS = [
         "name",

--- a/ns1/rest/client_classes.py
+++ b/ns1/rest/client_classes.py
@@ -7,7 +7,6 @@ from . import resource
 
 
 class ClientClasses(resource.BaseResource):
-
     ROOT = "dhcp"
     CLIENT_CLASS_ROOT = "clientclass"
 

--- a/ns1/rest/data.py
+++ b/ns1/rest/data.py
@@ -7,7 +7,6 @@ from . import resource
 
 
 class Source(resource.BaseResource):
-
     ROOT = "data/sources"
     PASSTHRU_FIELDS = ["name", "config"]
 
@@ -76,7 +75,6 @@ class Source(resource.BaseResource):
 
 
 class Feed(resource.BaseResource):
-
     ROOT = "data/feeds"
     PASSTHRU_FIELDS = ["name", "config"]
 

--- a/ns1/rest/monitoring.py
+++ b/ns1/rest/monitoring.py
@@ -7,7 +7,6 @@ from . import resource
 
 
 class Monitors(resource.BaseResource):
-
     ROOT = "monitoring/jobs"
     PASSTHRU_FIELDS = [
         "name",
@@ -69,7 +68,6 @@ class Monitors(resource.BaseResource):
 
 
 class NotifyLists(resource.BaseResource):
-
     ROOT = "lists"
     PASSTHRU_FIELDS = []
 
@@ -116,7 +114,6 @@ class NotifyLists(resource.BaseResource):
 
 
 class JobTypes(resource.BaseResource):
-
     ROOT = "monitoring/jobtypes"
     PASSTHRU_FIELDS = []
 
@@ -130,7 +127,6 @@ class JobTypes(resource.BaseResource):
 
 
 class Regions(resource.BaseResource):
-
     ROOT = "monitoring/regions"
     PASSTHRU_FIELDS = []
 

--- a/ns1/rest/pools.py
+++ b/ns1/rest/pools.py
@@ -7,7 +7,6 @@ from . import resource
 
 
 class Pools(resource.BaseResource):
-
     ROOT = "ipam"
     ADDRESS_ROOT = "address"
     POOL_ROOT = "pool"

--- a/ns1/rest/records.py
+++ b/ns1/rest/records.py
@@ -15,7 +15,6 @@ py_str = str if sys.version_info[0] == 3 else basestring  # noqa: F821
 
 
 class Records(resource.BaseResource):
-
     ROOT = "zones"
 
     INT_FIELDS = ["ttl"]

--- a/ns1/rest/resource.py
+++ b/ns1/rest/resource.py
@@ -13,7 +13,6 @@ from ns1.rest.errors import ResourceException
 
 
 class BaseResource:
-
     DEFAULT_TRANSPORT = "requests"
 
     INT_FIELDS = []

--- a/ns1/rest/stats.py
+++ b/ns1/rest/stats.py
@@ -12,7 +12,6 @@ except:  # noqa
 
 
 class Stats(resource.BaseResource):
-
     ROOT = "stats"
 
     def qps(
@@ -59,7 +58,7 @@ class Stats(resource.BaseResource):
 
         return self._make_request(
             "GET",
-            url + ('?' + urlencode(args) if args else ''),
+            url + ("?" + urlencode(args) if args else ""),
             callback=callback,
             errback=errback,
             pagination_handler=stats_usage_pagination,

--- a/ns1/rest/team.py
+++ b/ns1/rest/team.py
@@ -8,7 +8,6 @@ from . import resource
 
 
 class Team(resource.BaseResource):
-
     ROOT = "account/teams"
     PASSTHRU_FIELDS = ["name", "ip_whitelist", "permissions"]
 

--- a/ns1/rest/transport/base.py
+++ b/ns1/rest/transport/base.py
@@ -8,7 +8,6 @@ import logging
 
 
 class TransportBase(object):
-
     REGISTRY = {}
 
     def __init__(self, config, module):

--- a/ns1/rest/user.py
+++ b/ns1/rest/user.py
@@ -8,7 +8,6 @@ from . import resource
 
 
 class User(resource.BaseResource):
-
     ROOT = "account/users"
     PASSTHRU_FIELDS = [
         "name",

--- a/ns1/rest/views.py
+++ b/ns1/rest/views.py
@@ -7,7 +7,6 @@ from . import resource
 
 
 class Views(resource.BaseResource):
-
     ROOT = "views"
     INT_FIELDS = [
         "preference",

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -110,12 +110,7 @@ class Zones(resource.BaseResource):
             errback=errback,
         )
 
-    def list_versions(
-            self,
-            zone,
-            callback=None,
-            errback=None
-    ):
+    def list_versions(self, zone, callback=None, errback=None):
         request = "{}/{}/versions".format(self.ROOT, zone)
         return self._make_request(
             "GET",
@@ -125,12 +120,7 @@ class Zones(resource.BaseResource):
             errback=errback,
         )
 
-    def create_version(
-            self,
-            zone,
-            force=False,
-            callback=None,
-            errback=None):
+    def create_version(self, zone, force=False, callback=None, errback=None):
         request = "{}/{}/versions?force={}".format(
             self.ROOT, zone, str.lower(str(force))
         )
@@ -142,12 +132,7 @@ class Zones(resource.BaseResource):
             errback=errback,
         )
 
-    def activate_version(
-            self,
-            zone,
-            version_id,
-            callback=None,
-            errback=None):
+    def activate_version(self, zone, version_id, callback=None, errback=None):
         request = "{}/{}/versions/{}/activate".format(
             self.ROOT, zone, str(version_id)
         )
@@ -159,15 +144,8 @@ class Zones(resource.BaseResource):
             errback=errback,
         )
 
-    def delete_version(
-            self,
-            zone,
-            version_id,
-            callback=None,
-            errback=None):
-        request = "{}/{}/versions/{}".format(
-            self.ROOT, zone, str(version_id)
-        )
+    def delete_version(self, zone, version_id, callback=None, errback=None):
+        request = "{}/{}/versions/{}".format(self.ROOT, zone, str(version_id))
         return self._make_request(
             "DELETE",
             request,

--- a/ns1/zones.py
+++ b/ns1/zones.py
@@ -123,7 +123,6 @@ class Zone(object):
             )
 
     def __getattr__(self, item):
-
         if not item.startswith("add_"):
             raise AttributeError(item)
 
@@ -160,7 +159,6 @@ class Zone(object):
         errback=None,
         **kwargs
     ):
-
         """
         Create a new linked record in this zone. These records use the
         configuration (answers, ttl, filters, etc) from an existing record

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -52,59 +52,52 @@ def test_rest_zone_retrieve(zones_config, zone, url):
     )
 
 
-@pytest.mark.parametrize("zone, url", [("test.zone", "zones/test.zone/versions")])
+@pytest.mark.parametrize(
+    "zone, url", [("test.zone", "zones/test.zone/versions")]
+)
 def test_rest_zone_version_list(zones_config, zone, url):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()
     z.list_versions(zone)
     z._make_request.assert_called_once_with(
-        "GET",
-        url,
-        params={},
-        callback=None,
-        errback=None
+        "GET", url, params={}, callback=None, errback=None
     )
 
 
-@pytest.mark.parametrize("zone, url", [("test.zone", "zones/test.zone/versions?force=false")])
+@pytest.mark.parametrize(
+    "zone, url", [("test.zone", "zones/test.zone/versions?force=false")]
+)
 def test_rest_zone_version_create(zones_config, zone, url):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()
     z.create_version(zone)
     z._make_request.assert_called_once_with(
-        "PUT",
-        url,
-        params={},
-        callback=None,
-        errback=None
+        "PUT", url, params={}, callback=None, errback=None
     )
 
 
-@pytest.mark.parametrize("zone, id, url", [("test.zone", 15, "zones/test.zone/versions/15/activate")])
+@pytest.mark.parametrize(
+    "zone, id, url",
+    [("test.zone", 15, "zones/test.zone/versions/15/activate")],
+)
 def test_rest_zone_version_activate(zones_config, zone, id, url):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()
     z.activate_version(zone, id)
     z._make_request.assert_called_once_with(
-        "POST",
-        url,
-        params={},
-        callback=None,
-        errback=None
+        "POST", url, params={}, callback=None, errback=None
     )
 
 
-@pytest.mark.parametrize("zone, id, url", [("test.zone", 15, "zones/test.zone/versions/15")])
+@pytest.mark.parametrize(
+    "zone, id, url", [("test.zone", 15, "zones/test.zone/versions/15")]
+)
 def test_rest_zone_version_delete(zones_config, zone, id, url):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()
     z.delete_version(zone, id)
     z._make_request.assert_called_once_with(
-        "DELETE",
-        url,
-        params={},
-        callback=None,
-        errback=None
+        "DELETE", url, params={}, callback=None, errback=None
     )
 
 


### PR DESCRIPTION
We have a GitHub Action that checks the code using the `black` formatter. We should actually format our code using this to allow the check to pass.