### PR TITLE
Zone file import - support missing params.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.21.1 (Oct 29th, 2024)
+
+ENHANCEMENTS:
+* Adds support for specifying a list of views when creating zones with or without a provided zone file.
+* Adds support for specifying a zone name other than the FQDN when creating zones with or without a provided zone file.
+* A specified list of networks for a zone was only applied to zone creation when a zone file was not provided. 
+
 ## 0.21.0 (July 19th, 2024)
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.21.1 (Oct 29th, 2024)
+## 0.22.0 (Oct 29th, 2024)
 
 ENHANCEMENTS:
 * Adds support for specifying a list of views when creating zones with or without a provided zone file.

--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -271,7 +271,13 @@ class NS1:
         return rest_zone.search(query, type, expand, max, callback, errback)
 
     def createZone(
-        self, zone, name=None, zoneFile=None, callback=None, errback=None, **kwargs
+        self,
+        zone,
+        name=None,
+        zoneFile=None,
+        callback=None,
+        errback=None,
+        **kwargs
     ):
         """
         Create a new zone, and return an associated high level Zone object.
@@ -296,7 +302,11 @@ class NS1:
         zone = ns1.zones.Zone(self.config, zone)
 
         return zone.create(
-            zoneFile=zoneFile, name=name, callback=callback, errback=errback, **kwargs
+            zoneFile=zoneFile,
+            name=name,
+            callback=callback,
+            errback=errback,
+            **kwargs
         )
 
     def loadRecord(

--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -271,7 +271,7 @@ class NS1:
         return rest_zone.search(query, type, expand, max, callback, errback)
 
     def createZone(
-        self, zone, zoneFile=None, callback=None, errback=None, **kwargs
+        self, zone, name=None, zoneFile=None, callback=None, errback=None, **kwargs
     ):
         """
         Create a new zone, and return an associated high level Zone object.
@@ -281,7 +281,8 @@ class NS1:
         If zoneFile is specified, upload the specific zone definition file
         to populate the zone with.
 
-        :param str zone: zone name, like 'example.com'
+        :param str zone: zone FQDN, like 'example.com'
+        :param str zone: zone name override, name will be zone FQDN if omitted
         :param str zoneFile: absolute path of a zone file
         :keyword int retry: retry time
         :keyword int refresh: refresh ttl
@@ -295,7 +296,7 @@ class NS1:
         zone = ns1.zones.Zone(self.config, zone)
 
         return zone.create(
-            zoneFile=zoneFile, callback=callback, errback=errback, **kwargs
+            zoneFile=zoneFile, name=name, callback=callback, errback=errback, **kwargs
         )
 
     def loadRecord(

--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -5,7 +5,7 @@
 #
 from .config import Config
 
-version = "0.21.0"
+version = "0.21.1"
 
 
 class NS1:

--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -273,10 +273,10 @@ class NS1:
     def createZone(
         self,
         zone,
-        name=None,
         zoneFile=None,
         callback=None,
         errback=None,
+        name=None,
         **kwargs
     ):
         """
@@ -288,8 +288,8 @@ class NS1:
         to populate the zone with.
 
         :param str zone: zone FQDN, like 'example.com'
-        :param str zone: zone name override, name will be zone FQDN if omitted
         :param str zoneFile: absolute path of a zone file
+        :param str name: zone name override, name will be zone FQDN if omitted
         :keyword int retry: retry time
         :keyword int refresh: refresh ttl
         :keyword int expiry: expiry ttl

--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -5,7 +5,7 @@
 #
 from .config import Config
 
-version = "0.21.1"
+version = "0.22.0"
 
 
 class NS1:

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -25,6 +25,11 @@ class Zones(resource.BaseResource):
     ]
     BOOL_FIELDS = ["dnssec"]
 
+    ZONEFILE_FIELDS = [
+        "networks",
+        "views",
+    ]
+
     def _buildBody(self, zone, **kwargs):
         body = {}
         body["zone"] = zone

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -43,7 +43,7 @@ class Zones(resource.BaseResource):
         params = self._buildImportParams(kwargs)
         return self._make_request(
             "PUT",
-            "import/zonefile/%s" % (zone),
+            "import/zonefile/{}".format(zone),
             files=files,
             params=params,
             callback=callback,
@@ -73,7 +73,7 @@ class Zones(resource.BaseResource):
             name = zone
         return self._make_request(
             "PUT",
-            "%s/%s" % (self.ROOT, name),
+            "{}/{}".format(self.ROOT, name),
             body=body,
             callback=callback,
             errback=errback,

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -37,10 +37,10 @@ class Zones(resource.BaseResource):
         return body
 
     def import_file(
-        self, zone, zoneFile, name=None, callback=None, errback=None, **kwargs
+        self, zone, zoneFile, callback=None, errback=None, **kwargs
     ):
         files = [("zonefile", (zoneFile, open(zoneFile, "rb"), "text/plain"))]
-        params = self._buildImportParams(kwargs, name=name)
+        params = self._buildImportParams(kwargs)
         return self._make_request(
             "PUT",
             "import/zonefile/%s" % (zone),
@@ -51,23 +51,23 @@ class Zones(resource.BaseResource):
         )
 
     # Extra import args are specified as query parameters not fields in a JSON object.
-    def _buildImportParams(self, fields, name=None):
+    def _buildImportParams(self, fields):
         params = {}
         # Arrays of values should be passed as multiple instances of the same
         # parameter but the zonefile API expects parameters containing comma
         # seperated values.
         if fields.get("networks") is not None:
-            networksStrs = map(str, fields["networks"])
-            networksParam = ",".join(networksStrs)
-            params["networks"] = networksParam
+            networks_strs = map(str, fields["networks"])
+            networks_param = ",".join(networks_strs)
+            params["networks"] = networks_param
         if fields.get("views") is not None:
-            viewsParam = ",".join(fields["views"])
-            params["views"] = viewsParam
-        if name is not None:
-            params["name"] = name
+            views_param = ",".join(fields["views"])
+            params["views"] = views_param
+        if fields.get("name") is not None:
+            params["name"] = fields.get("name")
         return params
 
-    def create(self, zone, name=None, callback=None, errback=None, **kwargs):
+    def create(self, zone, callback=None, errback=None, name=None, **kwargs):
         body = self._buildBody(zone, **kwargs)
         if name is None:
             name = zone

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -43,7 +43,7 @@ class Zones(resource.BaseResource):
         params = self._buildImportParams(kwargs)
         return self._make_request(
             "PUT",
-            "import/zonefile/{}".format(zone),
+            f"import/zonefile/{zone}",
             files=files,
             params=params,
             callback=callback,
@@ -57,7 +57,7 @@ class Zones(resource.BaseResource):
         # parameter but the zonefile API expects parameters containing comma
         # seperated values.
         if fields.get("networks") is not None:
-            networks_strs = map(str, fields["networks"])
+            networks_strs = [str(network) for network in fields["networks"]]
             networks_param = ",".join(networks_strs)
             params["networks"] = networks_param
         if fields.get("views") is not None:
@@ -73,7 +73,7 @@ class Zones(resource.BaseResource):
             name = zone
         return self._make_request(
             "PUT",
-            "{}/{}".format(self.ROOT, name),
+            f"{self.ROOT}/{name}",
             body=body,
             callback=callback,
             errback=errback,

--- a/ns1/zones.py
+++ b/ns1/zones.py
@@ -90,7 +90,7 @@ class Zone(object):
             self.zone, callback=success, errback=errback, **kwargs
         )
 
-    def create(self, zoneFile=None, callback=None, errback=None, **kwargs):
+    def create(self, name=None, zoneFile=None, callback=None, errback=None, **kwargs):
         """
         Create a new zone. Pass a list of keywords and their values to
         configure. For the list of keywords available for zone configuration,
@@ -113,13 +113,14 @@ class Zone(object):
             return self._rest.import_file(
                 self.zone,
                 zoneFile,
+                name=name,
                 callback=success,
                 errback=errback,
                 **kwargs
             )
         else:
             return self._rest.create(
-                self.zone, callback=success, errback=errback, **kwargs
+                self.zone, name=name, callback=success, errback=errback, **kwargs
             )
 
     def __getattr__(self, item):

--- a/ns1/zones.py
+++ b/ns1/zones.py
@@ -94,10 +94,15 @@ class Zone(object):
         """
         Create a new zone. Pass a list of keywords and their values to
         configure. For the list of keywords available for zone configuration,
-        see :attr:`ns1.rest.zones.Zones.INT_FIELDS` and
+        see :attr:`ns1.rest.zones.Zones.INT_FIELDS`,
+        :attr:`ns1.rest.zones.Zones.BOOL_FIELDS` and
         :attr:`ns1.rest.zones.Zones.PASSTHRU_FIELDS`
-        If zoneFile is passed, it should be a zone text file on the local disk
-        that will be used to populate the created zone file.
+        Use `name` to pass a unique name for the zone otherwise this will
+        default to the zone FQDN.
+        If zoneFile is passed, it should be a zone text file on the local
+        disk that will be used to populate the created zone file. When a
+        zoneFile is passed only `name` and
+        :attr:`ns1.rest.zones.Zones.ZONEFILE_FIELDS` are supported.
         """
         if self.data:
             raise ZoneException("zone already loaded")

--- a/ns1/zones.py
+++ b/ns1/zones.py
@@ -90,7 +90,9 @@ class Zone(object):
             self.zone, callback=success, errback=errback, **kwargs
         )
 
-    def create(self, name=None, zoneFile=None, callback=None, errback=None, **kwargs):
+    def create(
+        self, name=None, zoneFile=None, callback=None, errback=None, **kwargs
+    ):
         """
         Create a new zone. Pass a list of keywords and their values to
         configure. For the list of keywords available for zone configuration,
@@ -125,7 +127,11 @@ class Zone(object):
             )
         else:
             return self._rest.create(
-                self.zone, name=name, callback=success, errback=errback, **kwargs
+                self.zone,
+                name=name,
+                callback=success,
+                errback=errback,
+                **kwargs
             )
 
     def __getattr__(self, item):

--- a/ns1/zones.py
+++ b/ns1/zones.py
@@ -91,7 +91,7 @@ class Zone(object):
         )
 
     def create(
-        self, name=None, zoneFile=None, callback=None, errback=None, **kwargs
+        self, zoneFile=None, callback=None, errback=None, name=None, **kwargs
     ):
         """
         Create a new zone. Pass a list of keywords and their values to
@@ -120,17 +120,17 @@ class Zone(object):
             return self._rest.import_file(
                 self.zone,
                 zoneFile,
-                name=name,
                 callback=success,
                 errback=errback,
+                name=name,
                 **kwargs
             )
         else:
             return self._rest.create(
                 self.zone,
-                name=name,
                 callback=success,
                 errback=errback,
+                name=name,
                 **kwargs
             )
 

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -74,23 +74,24 @@ def test_rest_zone_create(zones_config, zone, name, url):
     z._make_request = mock.MagicMock()
     z.create(zone, name=name)
     z._make_request.assert_called_once_with(
-        "PUT", url, body={"zone":zone}, callback=None, errback=None
+        "PUT", url, body={"zone": zone}, callback=None, errback=None
     )
 
+
 @pytest.mark.parametrize(
-    "zone, name, url, networks, views",[
+    "zone, name, url, networks, views", [
         ("test.zone", None, "import/zonefile/test.zone", None, None),
         ("test.zone", "test.name", "import/zonefile/test.zone", None, None),
-        ("test.zone", "test.name", "import/zonefile/test.zone", [1,2,99], None),
+        ("test.zone", "test.name", "import/zonefile/test.zone", [1, 2, 99], None),
         ("test.zone", "test.name", "import/zonefile/test.zone", None, ["view1", "view2"]),
-        ("test.zone", "test.name", "import/zonefile/test.zone", [3,4,99], ["viewA", "viewB"]),
+        ("test.zone", "test.name", "import/zonefile/test.zone", [3, 4, 99], ["viewA", "viewB"]),
     ]
 )
 def test_rest_zone_import_file(zones_config, zone, name, url, networks, views):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()
     params = {}
-    networksStrs=None
+    networksStrs = None
     if networks is not None:
         networksStrs = map(str, networks)
         params['networks'] = ",".join(networksStrs)
@@ -105,6 +106,7 @@ def test_rest_zone_import_file(zones_config, zone, name, url, networks, views):
     z._make_request.assert_called_once_with(
         "PUT", url, files=mock.ANY, params=params, callback=None, errback=None
     )
+
 
 @pytest.mark.parametrize(
     "zone, url", [("test.zone", "zones/test.zone/versions?force=false")]

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -65,6 +65,46 @@ def test_rest_zone_version_list(zones_config, zone, url):
 
 
 @pytest.mark.parametrize(
+    "zone, name, url", [("test.zone", None, "zones/test.zone"),
+                        ("test.zone", "test.name", "zones/test.name")]
+)
+def test_rest_zone_create(zones_config, zone, name, url):
+    z = ns1.rest.zones.Zones(zones_config)
+    z._make_request = mock.MagicMock()
+    z.create(zone, name=name)
+    z._make_request.assert_called_once_with(
+        "PUT", url, body={"zone":zone}, callback=None, errback=None
+    )
+
+@pytest.mark.parametrize(
+    "zone, name, url, networks, views",[
+        ("test.zone", None, "import/zonefile/test.zone", None, None),
+        ("test.zone", "test.name", "import/zonefile/test.zone", None, None),
+        ("test.zone", "test.name", "import/zonefile/test.zone", [1,2,99], None),
+        ("test.zone", "test.name", "import/zonefile/test.zone", None, ["view1", "view2"]),
+        ("test.zone", "test.name", "import/zonefile/test.zone", [3,4,99], ["viewA", "viewB"]),
+    ]
+)
+def test_rest_zone_import_file(zones_config, zone, name, url, networks, views):
+    z = ns1.rest.zones.Zones(zones_config)
+    z._make_request = mock.MagicMock()
+    params = {}
+    networksStrs=None
+    if networks is not None:
+        networksStrs = map(str, networks)
+        params['networks'] = ",".join(networksStrs)
+    if views is not None:
+        params['views'] = ",".join(views)
+    if name is not None:
+        params['name'] = name
+
+    z.import_file(zone,  "../examples/importzone.db", name=name, networks=networks, views=views)
+
+    z._make_request.assert_called_once_with(
+        "PUT", url, files=mock.ANY, params=params, callback=None, errback=None
+    )
+
+@pytest.mark.parametrize(
     "zone, url", [("test.zone", "zones/test.zone/versions?force=false")]
 )
 def test_rest_zone_version_create(zones_config, zone, url):

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -66,8 +66,11 @@ def test_rest_zone_version_list(zones_config, zone, url):
 
 
 @pytest.mark.parametrize(
-    "zone, name, url", [("test.zone", None, "zones/test.zone"),
-                        ("test.zone", "test.name", "zones/test.name")]
+    "zone, name, url",
+    [
+        ("test.zone", None, "zones/test.zone"),
+        ("test.zone", "test.name", "zones/test.name"),
+    ],
 )
 def test_rest_zone_create(zones_config, zone, name, url):
     z = ns1.rest.zones.Zones(zones_config)
@@ -79,13 +82,32 @@ def test_rest_zone_create(zones_config, zone, name, url):
 
 
 @pytest.mark.parametrize(
-    "zone, name, url, networks, views", [
+    "zone, name, url, networks, views",
+    [
         ("test.zone", None, "import/zonefile/test.zone", None, None),
         ("test.zone", "test.name", "import/zonefile/test.zone", None, None),
-        ("test.zone", "test.name", "import/zonefile/test.zone", [1, 2, 99], None),
-        ("test.zone", "test.name", "import/zonefile/test.zone", None, ["view1", "view2"]),
-        ("test.zone", "test.name", "import/zonefile/test.zone", [3, 4, 99], ["viewA", "viewB"]),
-    ]
+        (
+            "test.zone",
+            "test.name",
+            "import/zonefile/test.zone",
+            [1, 2, 99],
+            None,
+        ),
+        (
+            "test.zone",
+            "test.name",
+            "import/zonefile/test.zone",
+            None,
+            ["view1", "view2"],
+        ),
+        (
+            "test.zone",
+            "test.name",
+            "import/zonefile/test.zone",
+            [3, 4, 99],
+            ["viewA", "viewB"],
+        ),
+    ],
 )
 def test_rest_zone_import_file(zones_config, zone, name, url, networks, views):
     z = ns1.rest.zones.Zones(zones_config)
@@ -94,14 +116,18 @@ def test_rest_zone_import_file(zones_config, zone, name, url, networks, views):
     networksStrs = None
     if networks is not None:
         networksStrs = map(str, networks)
-        params['networks'] = ",".join(networksStrs)
+        params["networks"] = ",".join(networksStrs)
     if views is not None:
-        params['views'] = ",".join(views)
+        params["views"] = ",".join(views)
     if name is not None:
-        params['name'] = name
+        params["name"] = name
 
-    zoneFilePath = "{}/../../examples/importzone.db".format(os.path.dirname(os.path.abspath(__file__)))
-    z.import_file(zone,  zoneFilePath, name=name, networks=networks, views=views)
+    zoneFilePath = "{}/../../examples/importzone.db".format(
+        os.path.dirname(os.path.abspath(__file__))
+    )
+    z.import_file(
+        zone, zoneFilePath, name=name, networks=networks, views=views
+    )
 
     z._make_request.assert_called_once_with(
         "PUT", url, files=mock.ANY, params=params, callback=None, errback=None

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -1,5 +1,6 @@
 import ns1.rest.zones
 import pytest
+import os
 
 try:  # Python 3.3 +
     import unittest.mock as mock
@@ -98,7 +99,8 @@ def test_rest_zone_import_file(zones_config, zone, name, url, networks, views):
     if name is not None:
         params['name'] = name
 
-    z.import_file(zone,  "../examples/importzone.db", name=name, networks=networks, views=views)
+    zoneFilePath = "{}/../../examples/importzone.db".format(os.path.dirname(os.path.abspath(__file__)))
+    z.import_file(zone,  zoneFilePath, name=name, networks=networks, views=views)
 
     z._make_request.assert_called_once_with(
         "PUT", url, files=mock.ANY, params=params, callback=None, errback=None

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -82,6 +82,37 @@ def test_rest_zone_create(zones_config, zone, name, url):
 
 
 @pytest.mark.parametrize(
+    "zone, name, url, params",
+    [
+        ("test.zone", None, "zones/test.zone", {}),
+        ("test.zone", "test.name", "zones/test.name", {}),
+        ("test.zone", "test2.name", "zones/test2.name", {"networks": [1, 2]}),
+        (
+            "test.zone",
+            "test3.name",
+            "zones/test3.name",
+            {"networks": [1, 2], "views": "testview"},
+        ),
+        (
+            "test.zone",
+            "test4.name",
+            "zones/test4.name",
+            {"hostmaster": "example:example.com"},
+        ),
+    ],
+)
+def test_rest_zone_create_with_params(zones_config, zone, name, url, params):
+    z = ns1.rest.zones.Zones(zones_config)
+    z._make_request = mock.MagicMock()
+    z.create(zone, name=name, **params)
+    body = params
+    body["zone"] = zone
+    z._make_request.assert_called_once_with(
+        "PUT", url, body=body, callback=None, errback=None
+    )
+
+
+@pytest.mark.parametrize(
     "zone, name, url, networks, views",
     [
         ("test.zone", None, "import/zonefile/test.zone", None, None),
@@ -113,24 +144,51 @@ def test_rest_zone_import_file(zones_config, zone, name, url, networks, views):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()
     params = {}
-    networksStrs = None
+    networks_strs = None
     if networks is not None:
-        networksStrs = map(str, networks)
-        params["networks"] = ",".join(networksStrs)
+        networks_strs = map(str, networks)
+        params["networks"] = ",".join(networks_strs)
     if views is not None:
         params["views"] = ",".join(views)
-    if name is not None:
-        params["name"] = name
 
     zoneFilePath = "{}/../../examples/importzone.db".format(
         os.path.dirname(os.path.abspath(__file__))
     )
+
+    def cb():
+        # Should never be printed but provides a function body.
+        print("Callback invoked!")
+
+    # Test without zone name parameter
     z.import_file(
-        zone, zoneFilePath, name=name, networks=networks, views=views
+        zone,
+        zoneFilePath,
+        callback=cb,
+        errback=None,
+        networks=networks,
+        views=views,
     )
 
     z._make_request.assert_called_once_with(
-        "PUT", url, files=mock.ANY, params=params, callback=None, errback=None
+        "PUT", url, files=mock.ANY, callback=cb, errback=None, params=params
+    )
+
+    # Test with new zone name parameter (extra argument)
+    z._make_request.reset_mock()
+
+    if name is not None:
+        params["name"] = name
+    z.import_file(
+        zone,
+        zoneFilePath,
+        networks=networks,
+        views=views,
+        name=name,
+        callback=cb,
+    )
+
+    z._make_request.assert_called_once_with(
+        "PUT", url, files=mock.ANY, callback=cb, errback=None, params=params
     )
 
 


### PR DESCRIPTION
This PR adds support for missing parameters when importing zone files:
- networks
- views
- name

As both zone creation with or without a zone file to prepopulate it use the same call, just with or without the zonefile specificed, the "name" field also added to the api to create a zone and "views" is added to the list of fields passed through on zone creation. 