### PR TITLE
Add support for mTLS-capable HTTP proxy with self-signed certs

### DIFF
--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -24,17 +24,21 @@ class NS1:
         """
         self.config = config
 
-        if self.config is None:
-            self._loadConfig(apiKey, configFile)
+        if not isinstance(self.config, Config):
+            self._loadConfig(apiKey, config, configFile)
 
         if keyID:
             self.config.useKeyID(keyID)
 
-    def _loadConfig(self, apiKey, configFile):
+    def _loadConfig(self, apiKey, config, configFile):
         self.config = Config()
 
         if apiKey:
-            self.config.createFromAPIKey(apiKey)
+            if config is None:
+                config = {}
+            config["apiKey"] = apiKey
+
+            self.config.loadFromDict(config)
         else:
             configFile = (
                 Config.DEFAULT_CONFIG_FILE if not configFile else configFile

--- a/ns1/config.py
+++ b/ns1/config.py
@@ -84,6 +84,15 @@ class Config:
         if "follow_pagination" not in self._data:
             self._data["follow_pagination"] = False
 
+        if "http_proxy" not in self._data:
+            self._data["proxy"] = None
+
+        if "client_cert" not in self._data:
+            self._data["client_cert"] = None
+
+        if "cert_verify" not in self._data:
+            self._data["cert_verify"] = True
+
     def createFromAPIKey(self, apikey, maybeWriteDefault=False):
         """
         Create a basic config from a single API key
@@ -109,7 +118,11 @@ class Config:
 
         :param dict d: Python dictionary containing configuration items
         """
-        self._data = d
+        apikey = d.pop("apiKey", None)
+        if apikey:
+            self.createFromAPIKey(apikey)
+
+        self._data.update(d)
         self._doDefaults()
 
     def loadFromString(self, body):

--- a/ns1/rest/transport/requests.py
+++ b/ns1/rest/transport/requests.py
@@ -26,7 +26,13 @@ class RequestsTransport(TransportBase):
         if not have_requests:
             raise ImportError("requests module required for RequestsTransport")
         TransportBase.__init__(self, config, self.__module__)
+
         self.session = requests.Session()
+        if self._config.get("http_proxy", None):
+            self.session.proxies = {"https": self._config["http_proxy"]}
+        self.session.cert = self._config.get("client_cert")
+        self.session.verify = self._config.get("cert_verify", True)
+
         self.REQ_MAP = {
             "GET": self.session.get,
             "POST": self.session.post,


### PR DESCRIPTION
Secure environments commonly use mutual TLS (mTLS)-capable HTTP proxies to ensure only approved clients are able to make outbound calls to only approved endpoints on the Internet. The client certificates for mTLS can be self-signed or using a custom CA.

This PR adds the support for doing the above when `requests` transport is used.

For passing the necessary config parameters to `NS1` instance, the config in-take is also reworked in this PR to accept arbitrary dictionary in addition to API key. This is rework is designed to be backwards compatible.

An example use of this feature would be:
```python
NS1(
  apiKey='super-secret',
  config={
    'http_proxy': 'http://proxy.corp.com',
    'client_cert': ('path/to/cert', 'path/to/key'),
    'cert_verify': 'path/to/certfile',
    # optionally put api key here instead of above
    'apiKey': 'super-secret,
  }
)
```