### PR TITLE
Update version number to 0.23.0

### DIFF
--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -5,7 +5,7 @@
 #
 from .config import Config
 
-version = "0.22.0"
+version = "0.23.0"
 
 
 class NS1:


### PR DESCRIPTION
The previous commit to add support for the alerts api missed updating the module version number in `__init__.py`.
See: https://github.com/ns1/ns1-python/pull/131