### PR TITLE
PENG-6243 - Introduce support for billing-usage APIs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python setup.py install
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install dependencies
@@ -37,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ target/
 
 # Virtual environments
 venv/
+
+# Editors
+.vscode/
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.24.0 (March 20th, 2025)
+
+ENHANCEMENTS:
+* Adds support for BillingUsage
+
 ## 0.23.0 (Dec 9th, 2024)
 
 ENHANCEMENTS:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ interface for managing zones, records, data feeds, and more.
 It supports synchronous and asynchronous transports.
 
 Python 3.8+ is supported. Automated tests are currently run
-against 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14.
+against 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13
 
 Installation
 ============

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ and includes both a simple NS1 REST API wrapper as well as a higher level
 interface for managing zones, records, data feeds, and more.
 It supports synchronous and asynchronous transports.
 
-Both python 2.7 and 3.3+ are supported. Automated tests are currently run
-against 2.7, 3.7, 3.8, 3.9 and 3.10.
+Python 3.8+ is supported. Automated tests are currently run
+against 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14.
 
 Installation
 ============

--- a/examples/billing_usage.py
+++ b/examples/billing_usage.py
@@ -31,7 +31,9 @@ print("####################")
 # GET BILLING USAGE FOR QUERIES   #
 ###################################
 
-usg = api.billing_usage().getQueriesUsage(fromUnix=1738368000, toUnix=1740614400)
+usg = api.billing_usage().getQueriesUsage(
+    fromUnix=1738368000, toUnix=1740614400
+)
 print("### QUERIES USAGE ###")
 print(usg)
 print("####################")
@@ -40,7 +42,9 @@ print("####################")
 # GET BILLING USAGE FOR DECISIONS #
 ###################################
 
-usg = api.billing_usage().getDecisionsUsage(fromUnix=1738368000, toUnix=1740614400)
+usg = api.billing_usage().getDecisionsUsage(
+    fromUnix=1738368000, toUnix=1740614400
+)
 print("### DECISIONS USAGE ###")
 print(usg)
 print("####################")

--- a/examples/billing_usage.py
+++ b/examples/billing_usage.py
@@ -1,0 +1,73 @@
+#
+# Copyright (c) 2025 NSONE, Inc.
+#
+# License under The MIT License (MIT). See LICENSE in project root.
+#
+
+from ns1 import NS1
+
+# NS1 will use config in ~/.nsone by default
+api = NS1()
+
+# to specify an apikey here instead, use:
+
+# from ns1 import Config
+# config = Config()
+# config.createFromAPIKey('<<CLEARTEXT API KEY>>')
+# api = NS1(config=config)
+
+config = api.config
+
+############################
+# GET BILLING USAGE LIMITS #
+############################
+
+limits = api.billing_usage().getLimits(fromUnix=1738368000, toUnix=1740614400)
+print("### USAGE LIMITS ###")
+print(limits)
+print("####################")
+
+###################################
+# GET BILLING USAGE FOR QUERIES   #
+###################################
+
+usg = api.billing_usage().getQueriesUsage(fromUnix=1738368000, toUnix=1740614400)
+print("### QUERIES USAGE ###")
+print(usg)
+print("####################")
+
+###################################
+# GET BILLING USAGE FOR DECISIONS #
+###################################
+
+usg = api.billing_usage().getDecisionsUsage(fromUnix=1738368000, toUnix=1740614400)
+print("### DECISIONS USAGE ###")
+print(usg)
+print("####################")
+
+###################################
+# GET BILLING USAGE FOR MONITORS #
+###################################
+
+usg = api.billing_usage().getMonitorsUsage()
+print("### MONITORS USAGE ###")
+print(usg)
+print("####################")
+
+###################################
+# GET BILLING USAGE FOR FILER CHAINS #
+###################################
+
+usg = api.billing_usage().getMonitorsUsage()
+print("### FILTER CHAINS USAGE ###")
+print(usg)
+print("####################")
+
+###################################
+# GET BILLING USAGE FOR RECORDS #
+###################################
+
+usg = api.billing_usage().getRecordsUsage()
+print("### RECORDS USAGE ###")
+print(usg)
+print("####################")

--- a/examples/billing_usage.py
+++ b/examples/billing_usage.py
@@ -19,8 +19,12 @@ api = NS1()
 
 config = api.config
 
-from_unix = int(datetime.datetime.fromisoformat("2025-02-01 00:00:00").strftime("%s"))
-to_unix = int(datetime.datetime.fromisoformat("2025-02-28 23:59:59").strftime("%s"))
+from_unix = int(
+    datetime.datetime.fromisoformat("2025-02-01 00:00:00").strftime("%s")
+)
+to_unix = int(
+    datetime.datetime.fromisoformat("2025-02-28 23:59:59").strftime("%s")
+)
 
 ############################
 # GET BILLING USAGE LIMITS #

--- a/examples/billing_usage.py
+++ b/examples/billing_usage.py
@@ -5,6 +5,7 @@
 #
 
 from ns1 import NS1
+import datetime
 
 # NS1 will use config in ~/.nsone by default
 api = NS1()
@@ -18,11 +19,14 @@ api = NS1()
 
 config = api.config
 
+from_unix = int(datetime.datetime.fromisoformat("2025-02-01 00:00:00").strftime("%s"))
+to_unix = int(datetime.datetime.fromisoformat("2025-02-28 23:59:59").strftime("%s"))
+
 ############################
 # GET BILLING USAGE LIMITS #
 ############################
 
-limits = api.billing_usage().getLimits(fromUnix=1738368000, toUnix=1740614400)
+limits = api.billing_usage().getLimits(from_unix, to_unix)
 print("### USAGE LIMITS ###")
 print(limits)
 print("####################")
@@ -31,9 +35,7 @@ print("####################")
 # GET BILLING USAGE FOR QUERIES   #
 ###################################
 
-usg = api.billing_usage().getQueriesUsage(
-    fromUnix=1738368000, toUnix=1740614400
-)
+usg = api.billing_usage().getQueriesUsage(from_unix, to_unix)
 print("### QUERIES USAGE ###")
 print(usg)
 print("####################")
@@ -42,9 +44,7 @@ print("####################")
 # GET BILLING USAGE FOR DECISIONS #
 ###################################
 
-usg = api.billing_usage().getDecisionsUsage(
-    fromUnix=1738368000, toUnix=1740614400
-)
+usg = api.billing_usage().getDecisionsUsage(from_unix, to_unix)
 print("### DECISIONS USAGE ###")
 print(usg)
 print("####################")

--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -1,11 +1,11 @@
 #
-# Copyright (c) 2014, 2024 NSONE, Inc.
+# Copyright (c) 2014, 2025 NSONE, Inc.
 #
 # License under The MIT License (MIT). See LICENSE in project root.
 #
 from .config import Config
 
-version = "0.23.0"
+version = "0.24.0"
 
 
 class NS1:
@@ -241,6 +241,15 @@ class NS1:
         import ns1.rest.alerts
 
         return ns1.rest.alerts.Alerts(self.config)
+
+    def billing_usage(self):
+        """
+        Return a new raw REST interface to BillingUsage resources
+        :rtype: :py:class:`ns1.rest.billing_usage.BillingUsage`
+        """
+        import ns1.rest.billing_usage
+
+        return ns1.rest.billing_usage.BillingUsage(self.config)
 
     # HIGH LEVEL INTERFACE
     def loadZone(self, zone, callback=None, errback=None):

--- a/ns1/config.py
+++ b/ns1/config.py
@@ -77,7 +77,9 @@ class Config:
             self._data["api_version"] = self.API_VERSION
 
         if "api_version_before_resource" not in self._data:
-            self._data["api_version_before_resource"] = self.API_VERSION_BEFORE_RESOURCE
+            self._data[
+                "api_version_before_resource"
+            ] = self.API_VERSION_BEFORE_RESOURCE
 
         if "cli" not in self._data:
             self._data["cli"] = {}

--- a/ns1/config.py
+++ b/ns1/config.py
@@ -32,7 +32,6 @@ class ConfigException(Exception):
 
 
 class Config:
-
     """A simple object for accessing and manipulating config files. These
     contains options and credentials for accessing the NS1 REST API.
     Config files are simple JSON text files.
@@ -77,9 +76,9 @@ class Config:
             self._data["api_version"] = self.API_VERSION
 
         if "api_version_before_resource" not in self._data:
-            self._data[
-                "api_version_before_resource"
-            ] = self.API_VERSION_BEFORE_RESOURCE
+            self._data["api_version_before_resource"] = (
+                self.API_VERSION_BEFORE_RESOURCE
+            )
 
         if "cli" not in self._data:
             self._data["cli"] = {}

--- a/ns1/config.py
+++ b/ns1/config.py
@@ -251,7 +251,7 @@ class Config:
         else:
             endpoint = self._data["endpoint"]
 
-        return "https://%s%s" % (endpoint, port)
+        return f"https://{endpoint}{port}"
 
     def getRateLimitingFunc(self):
         """

--- a/ns1/config.py
+++ b/ns1/config.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014 NSONE, Inc.
+# Copyright (c) 2014, 2025 NSONE, Inc.
 #
 # License under The MIT License (MIT). See LICENSE in project root.
 #
@@ -45,6 +45,10 @@ class Config:
 
     API_VERSION = "v1"
 
+    # API_VERSION_BEFORE_RESOURCE is a flag that determines whether the API_VERSION should go before the resource in the URL
+    # Example: https://api.nsone.net/v1/zones vs https://api.nsone.net/zones/v1
+    API_VERSION_BEFORE_RESOURCE = True
+
     DEFAULT_CONFIG_FILE = "~/.nsone"
 
     def __init__(self, path=None):
@@ -71,6 +75,9 @@ class Config:
 
         if "api_version" not in self._data:
             self._data["api_version"] = self.API_VERSION
+
+        if "api_version_before_resource" not in self._data:
+            self._data["api_version_before_resource"] = self.API_VERSION_BEFORE_RESOURCE
 
         if "cli" not in self._data:
             self._data["cli"] = {}
@@ -243,7 +250,7 @@ class Config:
         else:
             endpoint = self._data["endpoint"]
 
-        return "https://%s%s/%s/" % (endpoint, port, self._data["api_version"])
+        return "https://%s%s" % (endpoint, port)
 
     def getRateLimitingFunc(self):
         """

--- a/ns1/monitoring.py
+++ b/ns1/monitoring.py
@@ -12,7 +12,6 @@ class MonitorException(Exception):
 
 
 class Monitor(object):
-
     """
     High level object representing a Monitor
     """

--- a/ns1/records.py
+++ b/ns1/records.py
@@ -13,7 +13,6 @@ class RecordException(Exception):
 
 
 class Record(object):
-
     """
     High level object representing a Record
     """

--- a/ns1/rest/billing_usage.py
+++ b/ns1/rest/billing_usage.py
@@ -24,7 +24,9 @@ class BillingUsage(resource.BaseResource):
             params={"from": from_unix, "to": to_unix},
         )
 
-    def getDecisionsUsage(self, from_unix, to_unix, callback=None, errback=None):
+    def getDecisionsUsage(
+        self, from_unix, to_unix, callback=None, errback=None
+    ):
         return self._make_request(
             "GET",
             f"{self.ROOT}/decisions",

--- a/ns1/rest/billing_usage.py
+++ b/ns1/rest/billing_usage.py
@@ -12,7 +12,7 @@ class BillingUsage(resource.BaseResource):
 
     def __init__(self, config):
         config = copy.deepcopy(config)
-        config['api_version_before_resource'] = False
+        config["api_version_before_resource"] = False
         super(BillingUsage, self).__init__(config)
 
     def getQueriesUsage(self, fromUnix, toUnix, callback=None, errback=None):
@@ -21,7 +21,7 @@ class BillingUsage(resource.BaseResource):
             "%s/queries" % self.ROOT,
             callback=callback,
             errback=errback,
-            params={'from': fromUnix, 'to': toUnix},
+            params={"from": fromUnix, "to": toUnix},
         )
 
     def getDecisionsUsage(self, fromUnix, toUnix, callback=None, errback=None):
@@ -30,7 +30,7 @@ class BillingUsage(resource.BaseResource):
             "%s/decisions" % self.ROOT,
             callback=callback,
             errback=errback,
-            params={'from': fromUnix, 'to': toUnix},
+            params={"from": fromUnix, "to": toUnix},
         )
 
     def getRecordsUsage(self, callback=None, errback=None):
@@ -66,5 +66,5 @@ class BillingUsage(resource.BaseResource):
             "%s/limits" % self.ROOT,
             callback=callback,
             errback=errback,
-            params={'from': fromUnix, 'to': toUnix},
+            params={"from": fromUnix, "to": toUnix},
         )

--- a/ns1/rest/billing_usage.py
+++ b/ns1/rest/billing_usage.py
@@ -1,0 +1,70 @@
+#
+# Copyright (c) 2025 NSONE, Inc.
+#
+# License under The MIT License (MIT). See LICENSE in project root.
+#
+from . import resource
+import copy
+
+
+class BillingUsage(resource.BaseResource):
+    ROOT = "billing-usage"
+
+    def __init__(self, config):
+        config = copy.deepcopy(config)
+        config['api_version_before_resource'] = False
+        super(BillingUsage, self).__init__(config)
+
+    def getQueriesUsage(self, fromUnix, toUnix, callback=None, errback=None):
+        return self._make_request(
+            "GET",
+            "%s/queries" % self.ROOT,
+            callback=callback,
+            errback=errback,
+            params={'from': fromUnix, 'to': toUnix},
+        )
+
+    def getDecisionsUsage(self, fromUnix, toUnix, callback=None, errback=None):
+        return self._make_request(
+            "GET",
+            "%s/decisions" % self.ROOT,
+            callback=callback,
+            errback=errback,
+            params={'from': fromUnix, 'to': toUnix},
+        )
+
+    def getRecordsUsage(self, callback=None, errback=None):
+        return self._make_request(
+            "GET",
+            "%s/records" % self.ROOT,
+            callback=callback,
+            errback=errback,
+            params={},
+        )
+
+    def getMonitorsUsage(self, callback=None, errback=None):
+        return self._make_request(
+            "GET",
+            "%s/monitors" % self.ROOT,
+            callback=callback,
+            errback=errback,
+            params={},
+        )
+
+    def getFilterChainsUsage(self, callback=None, errback=None):
+        return self._make_request(
+            "GET",
+            "%s/filter-chains" % self.ROOT,
+            callback=callback,
+            errback=errback,
+            params={},
+        )
+
+    def getLimits(self, fromUnix, toUnix, callback=None, errback=None):
+        return self._make_request(
+            "GET",
+            "%s/limits" % self.ROOT,
+            callback=callback,
+            errback=errback,
+            params={'from': fromUnix, 'to': toUnix},
+        )

--- a/ns1/rest/billing_usage.py
+++ b/ns1/rest/billing_usage.py
@@ -15,28 +15,28 @@ class BillingUsage(resource.BaseResource):
         config["api_version_before_resource"] = False
         super(BillingUsage, self).__init__(config)
 
-    def getQueriesUsage(self, fromUnix, toUnix, callback=None, errback=None):
+    def getQueriesUsage(self, from_unix, to_unix, callback=None, errback=None):
         return self._make_request(
             "GET",
-            "%s/queries" % self.ROOT,
+            f"{self.ROOT}/queries",
             callback=callback,
             errback=errback,
-            params={"from": fromUnix, "to": toUnix},
+            params={"from": from_unix, "to": to_unix},
         )
 
-    def getDecisionsUsage(self, fromUnix, toUnix, callback=None, errback=None):
+    def getDecisionsUsage(self, from_unix, to_unix, callback=None, errback=None):
         return self._make_request(
             "GET",
-            "%s/decisions" % self.ROOT,
+            f"{self.ROOT}/decisions",
             callback=callback,
             errback=errback,
-            params={"from": fromUnix, "to": toUnix},
+            params={"from": from_unix, "to": to_unix},
         )
 
     def getRecordsUsage(self, callback=None, errback=None):
         return self._make_request(
             "GET",
-            "%s/records" % self.ROOT,
+            f"{self.ROOT}/records",
             callback=callback,
             errback=errback,
             params={},
@@ -45,7 +45,7 @@ class BillingUsage(resource.BaseResource):
     def getMonitorsUsage(self, callback=None, errback=None):
         return self._make_request(
             "GET",
-            "%s/monitors" % self.ROOT,
+            f"{self.ROOT}/monitors",
             callback=callback,
             errback=errback,
             params={},
@@ -54,17 +54,17 @@ class BillingUsage(resource.BaseResource):
     def getFilterChainsUsage(self, callback=None, errback=None):
         return self._make_request(
             "GET",
-            "%s/filter-chains" % self.ROOT,
+            f"{self.ROOT}/filter-chains",
             callback=callback,
             errback=errback,
             params={},
         )
 
-    def getLimits(self, fromUnix, toUnix, callback=None, errback=None):
+    def getLimits(self, from_unix, to_unix, callback=None, errback=None):
         return self._make_request(
             "GET",
-            "%s/limits" % self.ROOT,
+            f"{self.ROOT}/limits",
             callback=callback,
             errback=errback,
-            params={"from": fromUnix, "to": toUnix},
+            params={"from": from_unix, "to": to_unix},
         )

--- a/ns1/rest/resource.py
+++ b/ns1/rest/resource.py
@@ -56,10 +56,10 @@ class BaseResource:
                 body[f] = fields[f]
 
     def _make_url(self, path):
-        if self._config['api_version_before_resource']:
+        if self._config["api_version_before_resource"]:
             return "%s/%s/%s" % (
                 self._config.getEndpoint(),
-                self._config['api_version'],
+                self._config["api_version"],
                 path,
             )
 
@@ -68,7 +68,7 @@ class BaseResource:
         return "%s/%s/%s/%s" % (
             self._config.getEndpoint(),
             resource,
-            self._config['api_version'],
+            self._config["api_version"],
             sub_resource,
         )
 

--- a/ns1/rest/resource.py
+++ b/ns1/rest/resource.py
@@ -57,20 +57,11 @@ class BaseResource:
 
     def _make_url(self, path):
         if self._config["api_version_before_resource"]:
-            return "%s/%s/%s" % (
-                self._config.getEndpoint(),
-                self._config["api_version"],
-                path,
-            )
+            return f"{self._config.getEndpoint()}/{self._config['api_version']}/{path}"
 
         resource, sub_resource = path.split("/", 1)
 
-        return "%s/%s/%s/%s" % (
-            self._config.getEndpoint(),
-            resource,
-            self._config["api_version"],
-            sub_resource,
-        )
+        return f"{self._config.getEndpoint()}/{resource}/{self._config['api_version']}/{sub_resource}"
 
     def _make_request(self, type, path, **kwargs):
         VERBS = ["GET", "POST", "DELETE", "PUT"]

--- a/ns1/rest/resource.py
+++ b/ns1/rest/resource.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014 NSONE, Inc.
+# Copyright (c) 2014, 2025 NSONE, Inc.
 #
 # License under The MIT License (MIT). See LICENSE in project root.
 #
@@ -56,7 +56,21 @@ class BaseResource:
                 body[f] = fields[f]
 
     def _make_url(self, path):
-        return self._config.getEndpoint() + path
+        if self._config['api_version_before_resource']:
+            return "%s/%s/%s" % (
+                self._config.getEndpoint(),
+                self._config['api_version'],
+                path,
+            )
+
+        resource, sub_resource = path.split("/", 1)
+
+        return "%s/%s/%s/%s" % (
+            self._config.getEndpoint(),
+            resource,
+            self._config['api_version'],
+            sub_resource,
+        )
 
     def _make_request(self, type, path, **kwargs):
         VERBS = ["GET", "POST", "DELETE", "PUT"]

--- a/ns1/rest/transport/twisted.py
+++ b/ns1/rest/transport/twisted.py
@@ -247,9 +247,9 @@ class TwistedTransport(TransportBase):
 
             if headers is None:
                 headers = {}
-            headers[
-                "Content-Type"
-            ] = "multipart/form-data; boundary={}".format(boundary)
+            headers["Content-Type"] = (
+                "multipart/form-data; boundary={}".format(boundary)
+            )
             bProducer = FileBodyProducer(StringIO.StringIO(body))
 
         theaders = (

--- a/tests/unit/test_billing_usage.py
+++ b/tests/unit/test_billing_usage.py
@@ -24,7 +24,7 @@ def billing_usage_config(config):
     return config
 
 
-@pytest.mark.parametrize("url", [("billing-usage/queries")])
+@pytest.mark.parametrize("url", ["billing-usage/queries"])
 def test_rest_get_billing_usage_for_queries(billing_usage_config, url):
     z = NS1(config=billing_usage_config).billing_usage()
     z._make_request = mock.MagicMock()
@@ -38,7 +38,7 @@ def test_rest_get_billing_usage_for_queries(billing_usage_config, url):
     )
 
 
-@pytest.mark.parametrize("url", [("billing-usage/decisions")])
+@pytest.mark.parametrize("url", ["billing-usage/decisions"])
 def test_rest_get_billing_usage_for_decisions(billing_usage_config, url):
     z = NS1(config=billing_usage_config).billing_usage()
     z._make_request = mock.MagicMock()
@@ -52,7 +52,7 @@ def test_rest_get_billing_usage_for_decisions(billing_usage_config, url):
     )
 
 
-@pytest.mark.parametrize("url", [("billing-usage/records")])
+@pytest.mark.parametrize("url", ["billing-usage/records"])
 def test_rest_get_billing_usage_for_records(billing_usage_config, url):
     z = NS1(config=billing_usage_config).billing_usage()
     z._make_request = mock.MagicMock()
@@ -66,7 +66,7 @@ def test_rest_get_billing_usage_for_records(billing_usage_config, url):
     )
 
 
-@pytest.mark.parametrize("url", [("billing-usage/filter-chains")])
+@pytest.mark.parametrize("url", ["billing-usage/filter-chains"])
 def test_rest_get_billing_usage_for_filter_chains(billing_usage_config, url):
     z = NS1(config=billing_usage_config).billing_usage()
     z._make_request = mock.MagicMock()
@@ -80,7 +80,7 @@ def test_rest_get_billing_usage_for_filter_chains(billing_usage_config, url):
     )
 
 
-@pytest.mark.parametrize("url", [("billing-usage/monitors")])
+@pytest.mark.parametrize("url", ["billing-usage/monitors"])
 def test_rest_get_billing_usage_for_monitors(billing_usage_config, url):
     z = NS1(config=billing_usage_config).billing_usage()
     z._make_request = mock.MagicMock()
@@ -94,7 +94,7 @@ def test_rest_get_billing_usage_for_monitors(billing_usage_config, url):
     )
 
 
-@pytest.mark.parametrize("url", [("billing-usage/limits")])
+@pytest.mark.parametrize("url", ["billing-usage/limits"])
 def test_rest_get_billing_usage_limits(billing_usage_config, url):
     z = NS1(config=billing_usage_config).billing_usage()
     z._make_request = mock.MagicMock()

--- a/tests/unit/test_billing_usage.py
+++ b/tests/unit/test_billing_usage.py
@@ -2,11 +2,7 @@ import pytest
 
 from ns1 import NS1
 
-try:  # Python 3.3 +
-    import unittest.mock as mock
-except ImportError:
-    import mock
-
+import unittest.mock as mock
 
 @pytest.fixture
 def billing_usage_config(config):

--- a/tests/unit/test_billing_usage.py
+++ b/tests/unit/test_billing_usage.py
@@ -1,0 +1,112 @@
+import pytest
+
+import ns1.rest.billing_usage
+from ns1 import NS1
+
+try:  # Python 3.3 +
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+
+@pytest.fixture
+def billing_usage_config(config):
+    config.loadFromDict(
+        {
+            "endpoint": "api.nsone.net",
+            "default_key": "test1",
+            "keys": {
+                "test1": {
+                    "key": "key-1",
+                    "desc": "test key number 1",
+                    "writeLock": True,
+                }
+            },
+        }
+    )
+
+    return config
+
+
+@pytest.mark.parametrize("url", [("billing-usage/queries")])
+def test_rest_get_billing_usage_for_queries(billing_usage_config, url):
+    z = NS1(config=billing_usage_config).billing_usage()
+    z._make_request = mock.MagicMock()
+    z.getQueriesUsage(fromUnix=123, toUnix=456)
+    z._make_request.assert_called_once_with(
+        "GET",
+        url,
+        callback=None,
+        errback=None,
+        params={"from": 123, "to": 456},
+    )
+
+
+@pytest.mark.parametrize("url", [("billing-usage/decisions")])
+def test_rest_get_billing_usage_for_decisions(billing_usage_config, url):
+    z = NS1(config=billing_usage_config).billing_usage()
+    z._make_request = mock.MagicMock()
+    z.getDecisionsUsage(fromUnix=123, toUnix=456)
+    z._make_request.assert_called_once_with(
+        "GET",
+        url,
+        callback=None,
+        errback=None,
+        params={"from": 123, "to": 456},
+    )
+
+
+@pytest.mark.parametrize("url", [("billing-usage/records")])
+def test_rest_get_billing_usage_for_records(billing_usage_config, url):
+    z = NS1(config=billing_usage_config).billing_usage()
+    z._make_request = mock.MagicMock()
+    z.getRecordsUsage()
+    z._make_request.assert_called_once_with(
+        "GET",
+        url,
+        callback=None,
+        errback=None,
+        params={},
+    )
+
+
+@pytest.mark.parametrize("url", [("billing-usage/filter-chains")])
+def test_rest_get_billing_usage_for_filter_chains(billing_usage_config, url):
+    z = NS1(config=billing_usage_config).billing_usage()
+    z._make_request = mock.MagicMock()
+    z.getFilterChainsUsage()
+    z._make_request.assert_called_once_with(
+        "GET",
+        url,
+        callback=None,
+        errback=None,
+        params={},
+    )
+
+
+@pytest.mark.parametrize("url", [("billing-usage/monitors")])
+def test_rest_get_billing_usage_for_monitors(billing_usage_config, url):
+    z = NS1(config=billing_usage_config).billing_usage()
+    z._make_request = mock.MagicMock()
+    z.getMonitorsUsage()
+    z._make_request.assert_called_once_with(
+        "GET",
+        url,
+        callback=None,
+        errback=None,
+        params={},
+    )
+
+
+@pytest.mark.parametrize("url", [("billing-usage/limits")])
+def test_rest_get_billing_usage_for_monitors(billing_usage_config, url):
+    z = NS1(config=billing_usage_config).billing_usage()
+    z._make_request = mock.MagicMock()
+    z.getLimits(fromUnix=123, toUnix=456)
+    z._make_request.assert_called_once_with(
+        "GET",
+        url,
+        callback=None,
+        errback=None,
+        params={"from": 123, "to": 456},
+    )

--- a/tests/unit/test_billing_usage.py
+++ b/tests/unit/test_billing_usage.py
@@ -1,6 +1,5 @@
 import pytest
 
-import ns1.rest.billing_usage
 from ns1 import NS1
 
 try:  # Python 3.3 +
@@ -99,7 +98,7 @@ def test_rest_get_billing_usage_for_monitors(billing_usage_config, url):
 
 
 @pytest.mark.parametrize("url", [("billing-usage/limits")])
-def test_rest_get_billing_usage_for_monitors(billing_usage_config, url):
+def test_rest_get_billing_usage_limits(billing_usage_config, url):
     z = NS1(config=billing_usage_config).billing_usage()
     z._make_request = mock.MagicMock()
     z.getLimits(fromUnix=123, toUnix=456)

--- a/tests/unit/test_billing_usage.py
+++ b/tests/unit/test_billing_usage.py
@@ -28,7 +28,7 @@ def billing_usage_config(config):
 def test_rest_get_billing_usage_for_queries(billing_usage_config, url):
     z = NS1(config=billing_usage_config).billing_usage()
     z._make_request = mock.MagicMock()
-    z.getQueriesUsage(fromUnix=123, toUnix=456)
+    z.getQueriesUsage(from_unix=123, to_unix=456)
     z._make_request.assert_called_once_with(
         "GET",
         url,
@@ -42,7 +42,7 @@ def test_rest_get_billing_usage_for_queries(billing_usage_config, url):
 def test_rest_get_billing_usage_for_decisions(billing_usage_config, url):
     z = NS1(config=billing_usage_config).billing_usage()
     z._make_request = mock.MagicMock()
-    z.getDecisionsUsage(fromUnix=123, toUnix=456)
+    z.getDecisionsUsage(from_unix=123, to_unix=456)
     z._make_request.assert_called_once_with(
         "GET",
         url,
@@ -98,7 +98,7 @@ def test_rest_get_billing_usage_for_monitors(billing_usage_config, url):
 def test_rest_get_billing_usage_limits(billing_usage_config, url):
     z = NS1(config=billing_usage_config).billing_usage()
     z._make_request = mock.MagicMock()
-    z.getLimits(fromUnix=123, toUnix=456)
+    z.getLimits(from_unix=123, to_unix=456)
     z._make_request.assert_called_once_with(
         "GET",
         url,

--- a/tests/unit/test_billing_usage.py
+++ b/tests/unit/test_billing_usage.py
@@ -4,6 +4,7 @@ from ns1 import NS1
 
 import unittest.mock as mock
 
+
 @pytest.fixture
 def billing_usage_config(config):
     config.loadFromDict(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -82,5 +82,5 @@ def test_load_from_str(config):
     assert config.getCurrentKeyID() == key_cfg["default_key"]
     assert config["keys"] == key_cfg["keys"]
     assert config.getAPIKey() == key_cfg["keys"][key_cfg["default_key"]]["key"]
-    endpoint = "https://%s" % defaults["endpoint"]
+    endpoint = f'https://{defaults["endpoint"]}'
     assert config.getEndpoint() == endpoint

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,6 +10,7 @@ defaults = {
     "endpoint": "api.nsone.net",
     "port": 443,
     "api_version": "v1",
+    "api_version_before_resource": True,
     "cli": {},
     "ddi": False,
     "follow_pagination": False,
@@ -81,5 +82,5 @@ def test_load_from_str(config):
     assert config.getCurrentKeyID() == key_cfg["default_key"]
     assert config["keys"] == key_cfg["keys"]
     assert config.getAPIKey() == key_cfg["keys"][key_cfg["default_key"]]["key"]
-    endpoint = "https://%s/v1/" % defaults["endpoint"]
+    endpoint = "https://%s" % defaults["endpoint"]
     assert config.getEndpoint() == endpoint


### PR DESCRIPTION
1. Adds support for the billing usage endpoints
- `/billing-usage/v1/queries`
- `/billing-usage/v1/decisions`
- `/billing-usage/v1/monitors`
- `/billing-usage/v1/records`
- `/billing-usage/v1/filter-chains`
- `/billing-usage/v1/limits`

2. Updates supported python versions based on currently tested version
3. Fixes CI workflows for deprecated python versions