### PR TITLE
PENG-5835: Rename package to use underscores instead of dashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.27.0 (December 3rd, 2025)
+
+CHANGED:
+* Renamed package from `ns1-python` to `ns1_python` to comply with PEP 625
+
 ## 0.26.0 (August 28th, 2025)
 
 ENHANCEMENTS:

--- a/README.md
+++ b/README.md
@@ -89,3 +89,9 @@ pip install flake8 black
 flake8 . --count --show-source --statistics --extend-ignore=E501
 black . --check -l 79 --diff
 ```
+
+## NOTE
+
+This package was originally named `ns1-python`, but to comply with [PEP 625](https://peps.python.org/pep-0625/) it was renamed to `ns1_python` via [this PR](https://github.com/ns1/ns1-python/pull/142).
+
+You can still install the `ns1-python` package as normal.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ against 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13
 Installation
 ============
 
-    $ pip install ns1-python
+    $ pip install ns1_python
 
 Dependencies
 ============

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,7 +17,7 @@ Both python 2.7 and 3.3 are supported.
 
 Install with::
 
-  $ pip install ns1-python
+  $ pip install ns1_python
 
 
 Quick Start

--- a/examples/pulsar_decisions.py
+++ b/examples/pulsar_decisions.py
@@ -7,7 +7,7 @@
 """
 Example usage of Pulsar Decisions API endpoints.
 This example demonstrates how to query Pulsar decision analytics data
-using the ns1-python library.
+using the ns1_python library.
 """
 from ns1 import NS1
 import time

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(cwd, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    name="ns1-python",
+    name="ns1_python",
     # flake8: noqa
     version=ns1.version,
     description="Python SDK for the NS1 DNS platform",


### PR DESCRIPTION
As part of [PEP 625](https://peps.python.org/pep-0625/), package names with dashes (`-`) in them are no longer allowed, to be replaced by underscores (`_`).

This PR changes the name of the package, though users can still use the old package name (as of `v0.26.0`) and get the correctly named package.