### PR TITLE
PENG-7708-python-sdk-zoneexport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.28.0 (TBD)
+
+ENHANCEMENTS:
+* Add zone export functionality to export zones in BIND format for backup/migration
+
 ## 0.27.1 (December 3rd, 2025)
 
 FIXED:

--- a/examples/zone-export.py
+++ b/examples/zone-export.py
@@ -23,4 +23,3 @@ print(zone_file)
 # save to a file
 with open("example.com.zone", "w") as f:
     f.write(zone_file)
-

--- a/examples/zone-export.py
+++ b/examples/zone-export.py
@@ -15,19 +15,23 @@ api = NS1()
 # to load an alternate configuration file:
 # api = NS1(configFile='/etc/ns1/api.json')
 
+# Define the zone to export
+zone_name = "example.com"
+
 # Export a zone to BIND format
 # The export() method will:
 # 1. Initiate the export job
 # 2. Poll the status until complete or failed
 # 3. Download and return the zone file content
-zone = api.loadZone("example.com")
+zone = api.loadZone(zone_name)
 
-print("Exporting zone example.com...")
+print(f"Exporting zone {zone_name}...")
 zone_file = zone.export()
 print("Export complete!")
 print(zone_file)
 
 # Save to a file
-with open("example.com.txt", "w") as f:
+output_file = f"{zone_name}.txt"
+with open(output_file, "w") as f:
     f.write(zone_file)
-print("Zone file saved to example.com.txt")
+print(f"Zone file saved to {output_file}")

--- a/examples/zone-export.py
+++ b/examples/zone-export.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014 NSONE, Inc.
+# Copyright (c) 2025 NSONE, Inc.
 #
 # License under The MIT License (MIT). See LICENSE in project root.
 #
@@ -24,4 +24,3 @@ print(zone_file)
 with open("example.com.zone", "w") as f:
     f.write(zone_file)
 
-# Made with Bob

--- a/examples/zone-export.py
+++ b/examples/zone-export.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 NSONE, Inc.
+# Copyright (c) 2026 NSONE, Inc.
 #
 # License under The MIT License (MIT). See LICENSE in project root.
 #
@@ -31,5 +31,3 @@ print(zone_file)
 with open("example.com.txt", "w") as f:
     f.write(zone_file)
 print("Zone file saved to example.com.txt")
-
-# Made with Bob

--- a/examples/zone-export.py
+++ b/examples/zone-export.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2026 NSONE, Inc.
+# Copyright IBM Corp. 2026
 #
 # License under The MIT License (MIT). See LICENSE in project root.
 #

--- a/examples/zone-export.py
+++ b/examples/zone-export.py
@@ -15,11 +15,21 @@ api = NS1()
 # to load an alternate configuration file:
 # api = NS1(configFile='/etc/ns1/api.json')
 
-# export a zone to BIND format
+# Export a zone to BIND format
+# The export() method will:
+# 1. Initiate the export job
+# 2. Poll the status until complete or failed
+# 3. Download and return the zone file content
 zone = api.loadZone("example.com")
+
+print("Exporting zone example.com...")
 zone_file = zone.export()
+print("Export complete!")
 print(zone_file)
 
-# save to a file
-with open("example.com.zone", "w") as f:
+# Save to a file
+with open("example.com.txt", "w") as f:
     f.write(zone_file)
+print("Zone file saved to example.com.txt")
+
+# Made with Bob

--- a/examples/zone-export.py
+++ b/examples/zone-export.py
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2014 NSONE, Inc.
+#
+# License under The MIT License (MIT). See LICENSE in project root.
+#
+
+from ns1 import NS1
+
+# NS1 will use config in ~/.nsone by default
+api = NS1()
+
+# to specify an apikey here instead, use:
+# api = NS1(apiKey='<<CLEARTEXT API KEY>>')
+
+# to load an alternate configuration file:
+# api = NS1(configFile='/etc/ns1/api.json')
+
+# export a zone to BIND format
+zone = api.loadZone("example.com")
+zone_file = zone.export()
+print(zone_file)
+
+# save to a file
+with open("example.com.zone", "w") as f:
+    f.write(zone_file)
+
+# Made with Bob

--- a/examples/zone-export.py
+++ b/examples/zone-export.py
@@ -31,7 +31,6 @@ print("Export complete!")
 print(zone_file)
 
 # Save to a file
-output_file = f"{zone_name}.txt"
-with open(output_file, "w") as f:
+with open("example.com.txt", "w") as f:
     f.write(zone_file)
-print(f"Zone file saved to {output_file}")
+print("Zone file saved to example.com.txt")

--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -36,9 +36,7 @@ class NS1:
         if apiKey:
             self.config.createFromAPIKey(apiKey)
         else:
-            configFile = (
-                Config.DEFAULT_CONFIG_FILE if not configFile else configFile
-            )
+            configFile = Config.DEFAULT_CONFIG_FILE if not configFile else configFile
             self.config.loadFromFile(configFile)
 
     # REST INTERFACE
@@ -300,13 +298,7 @@ class NS1:
         return rest_zone.search(query, type, expand, max, callback, errback)
 
     def createZone(
-        self,
-        zone,
-        zoneFile=None,
-        callback=None,
-        errback=None,
-        name=None,
-        **kwargs
+        self, zone, zoneFile=None, callback=None, errback=None, name=None, **kwargs
     ):
         """
         Create a new zone, and return an associated high level Zone object.
@@ -331,11 +323,7 @@ class NS1:
         zone = ns1.zones.Zone(self.config, zone)
 
         return zone.create(
-            zoneFile=zoneFile,
-            name=name,
-            callback=callback,
-            errback=errback,
-            **kwargs
+            zoneFile=zoneFile, name=name, callback=callback, errback=errback, **kwargs
         )
 
     def loadRecord(
@@ -367,9 +355,7 @@ class NS1:
                 zone = ".".join(parts[1:])
         z = ns1.zones.Zone(self.config, zone)
 
-        return z.loadRecord(
-            domain, type, callback=callback, errback=errback, **kwargs
-        )
+        return z.loadRecord(domain, type, callback=callback, errback=errback, **kwargs)
 
     def loadMonitors(self, callback=None, errback=None, **kwargs):
         """

--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -36,7 +36,9 @@ class NS1:
         if apiKey:
             self.config.createFromAPIKey(apiKey)
         else:
-            configFile = Config.DEFAULT_CONFIG_FILE if not configFile else configFile
+            configFile = (
+                Config.DEFAULT_CONFIG_FILE if not configFile else configFile
+            )
             self.config.loadFromFile(configFile)
 
     # REST INTERFACE
@@ -298,7 +300,13 @@ class NS1:
         return rest_zone.search(query, type, expand, max, callback, errback)
 
     def createZone(
-        self, zone, zoneFile=None, callback=None, errback=None, name=None, **kwargs
+        self,
+        zone,
+        zoneFile=None,
+        callback=None,
+        errback=None,
+        name=None,
+        **kwargs
     ):
         """
         Create a new zone, and return an associated high level Zone object.
@@ -323,7 +331,11 @@ class NS1:
         zone = ns1.zones.Zone(self.config, zone)
 
         return zone.create(
-            zoneFile=zoneFile, name=name, callback=callback, errback=errback, **kwargs
+            zoneFile=zoneFile,
+            name=name,
+            callback=callback,
+            errback=errback,
+            **kwargs
         )
 
     def loadRecord(
@@ -355,7 +367,9 @@ class NS1:
                 zone = ".".join(parts[1:])
         z = ns1.zones.Zone(self.config, zone)
 
-        return z.loadRecord(domain, type, callback=callback, errback=errback, **kwargs)
+        return z.loadRecord(
+            domain, type, callback=callback, errback=errback, **kwargs
+        )
 
     def loadMonitors(self, callback=None, errback=None, **kwargs):
         """

--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -5,7 +5,7 @@
 #
 from .config import Config
 
-version = "0.27.1"
+version = "0.28.0"
 
 
 class NS1:

--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2025 NSONE, Inc.
+# Copyright IBM Corp. 2014, 2026
 #
 # License under The MIT License (MIT). See LICENSE in project root.
 #

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -36,9 +36,7 @@ class Zones(resource.BaseResource):
         self._buildStdBody(body, kwargs)
         return body
 
-    def import_file(
-        self, zone, zoneFile, callback=None, errback=None, **kwargs
-    ):
+    def import_file(self, zone, zoneFile, callback=None, errback=None, **kwargs):
         files = [("zonefile", (zoneFile, open(zoneFile, "rb"), "text/plain"))]
         params = self._buildImportParams(kwargs)
         return self._make_request(
@@ -147,9 +145,7 @@ class Zones(resource.BaseResource):
             errback=errback,
         )
 
-    def create_version(
-        self, zone, force=False, callback=None, errback=None, name=None
-    ):
+    def create_version(self, zone, force=False, callback=None, errback=None, name=None):
         if name is None:
             name = zone
         body = {}
@@ -167,9 +163,7 @@ class Zones(resource.BaseResource):
         )
 
     def activate_version(self, zone, version_id, callback=None, errback=None):
-        request = "{}/{}/versions/{}/activate".format(
-            self.ROOT, zone, str(version_id)
-        )
+        request = "{}/{}/versions/{}/activate".format(self.ROOT, zone, str(version_id))
         return self._make_request(
             "POST",
             request,
@@ -228,7 +222,7 @@ class Zones(resource.BaseResource):
         # The transport layer will try to parse it as JSON and fail
         # We catch that exception and extract the raw body text
         from ns1.rest.errors import ResourceException
-        
+
         try:
             return self._make_request(
                 "GET",
@@ -240,7 +234,7 @@ class Zones(resource.BaseResource):
             # If it's about invalid JSON, that's expected - extract the body
             if "invalid json in response" in str(e):
                 # The body is the third argument in ResourceException
-                if hasattr(e, 'args') and len(e.args) >= 3:
+                if hasattr(e, "args") and len(e.args) >= 3:
                     body = e.args[2]
                     if callback:
                         return callback(body)

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -188,6 +188,20 @@ class Zones(resource.BaseResource):
             errback=errback,
         )
 
+    def export(self, zone, callback=None, errback=None):
+        """
+        Export zone as BIND-compatible zone file.
+        
+        :param str zone: zone name
+        :return: zone file content as string
+        """
+        return self._make_request(
+            "GET",
+            f"{self.ROOT}/{zone}/export",
+            callback=callback,
+            errback=errback,
+        )
+
 
 # successive pages just extend the list of zones
 def zone_list_pagination(curr_json, next_json):

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -36,7 +36,9 @@ class Zones(resource.BaseResource):
         self._buildStdBody(body, kwargs)
         return body
 
-    def import_file(self, zone, zoneFile, callback=None, errback=None, **kwargs):
+    def import_file(
+        self, zone, zoneFile, callback=None, errback=None, **kwargs
+    ):
         files = [("zonefile", (zoneFile, open(zoneFile, "rb"), "text/plain"))]
         params = self._buildImportParams(kwargs)
         return self._make_request(
@@ -145,7 +147,9 @@ class Zones(resource.BaseResource):
             errback=errback,
         )
 
-    def create_version(self, zone, force=False, callback=None, errback=None, name=None):
+    def create_version(
+        self, zone, force=False, callback=None, errback=None, name=None
+    ):
         if name is None:
             name = zone
         body = {}
@@ -163,7 +167,9 @@ class Zones(resource.BaseResource):
         )
 
     def activate_version(self, zone, version_id, callback=None, errback=None):
-        request = "{}/{}/versions/{}/activate".format(self.ROOT, zone, str(version_id))
+        request = "{}/{}/versions/{}/activate".format(
+            self.ROOT, zone, str(version_id)
+        )
         return self._make_request(
             "POST",
             request,

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -202,6 +202,35 @@ class Zones(resource.BaseResource):
             errback=errback,
         )
 
+    def initiate_export(self, zone, callback=None, errback=None):
+        """
+        Initiate zone export job.
+
+        :param str zone: zone name
+        :return: export status response
+        """
+        return self._make_request(
+            "PUT",
+            f"export/zonefile/{zone}",
+            body={},
+            callback=callback,
+            errback=errback,
+        )
+
+    def export_status(self, zone, callback=None, errback=None):
+        """
+        Check zone export status.
+
+        :param str zone: zone name
+        :return: export status response
+        """
+        return self._make_request(
+            "GET",
+            f"export/zonefile/{zone}/status",
+            callback=callback,
+            errback=errback,
+        )
+
 
 # successive pages just extend the list of zones
 def zone_list_pagination(curr_json, next_json):

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -5,7 +5,6 @@
 #
 
 from . import resource
-from .errors import ResourceException
 
 
 class Zones(resource.BaseResource):

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -188,21 +188,7 @@ class Zones(resource.BaseResource):
             errback=errback,
         )
 
-    def export(self, zone, callback=None, errback=None):
-        """
-        Export zone as BIND-compatible zone file.
-
-        :param str zone: zone name
-        :return: zone file content as string
-        """
-        return self._make_request(
-            "GET",
-            f"{self.ROOT}/{zone}/export",
-            callback=callback,
-            errback=errback,
-        )
-
-    def initiate_export(self, zone, callback=None, errback=None):
+    def initiate_zonefile_export(self, zone, callback=None, errback=None):
         """
         Initiate zone export job.
 
@@ -217,7 +203,7 @@ class Zones(resource.BaseResource):
             errback=errback,
         )
 
-    def export_status(self, zone, callback=None, errback=None):
+    def status_zonefile_export(self, zone, callback=None, errback=None):
         """
         Check zone export status.
 
@@ -227,6 +213,20 @@ class Zones(resource.BaseResource):
         return self._make_request(
             "GET",
             f"export/zonefile/{zone}/status",
+            callback=callback,
+            errback=errback,
+        )
+
+    def get_zonefile_export(self, zone, callback=None, errback=None):
+        """
+        Download the exported zone file in BIND-compatible format.
+
+        :param str zone: zone name
+        :return: zone file content as string
+        """
+        return self._make_request(
+            "GET",
+            f"{self.ROOT}/{zone}/export",
             callback=callback,
             errback=errback,
         )

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014 NSONE, Inc.
+# Copyright IBM Corp. 2014, 2026
 #
 # License under The MIT License (MIT). See LICENSE in project root.
 #
@@ -225,27 +225,13 @@ class Zones(resource.BaseResource):
         :param str zone: zone name
         :return: zone file content as string
         """
-        # Note: This endpoint returns raw zone file text, not JSON
-        # The transport layer will try to parse it as JSON and fail
-        # We catch that exception and extract the raw body text
-        try:
-            return self._make_request(
-                "GET",
-                f"export/zonefile/{zone}",
-                callback=callback,
-                errback=errback,
-            )
-        except ResourceException as e:
-            # Check if this is a valid zonefile response (plain text)
-            # The response should be 200 OK with text/plain content
-            if e.response and e.response.getcode() == 200:
-                # Check content-type header for text/plain
-                content_type = e.response.getheader("Content-Type", "")
-                if "text/plain" in content_type or "text" in content_type:
-                    # This is the expected plain text zonefile
-                    return e.body if e.body else ""
-            # Otherwise, this is a real error - re-raise it
-            raise
+        return self._make_request(
+            "GET",
+            f"export/zonefile/{zone}",
+            callback=callback,
+            errback=errback,
+            skip_json_parsing=True,
+        )
 
 
 # successive pages just extend the list of zones

--- a/ns1/rest/zones.py
+++ b/ns1/rest/zones.py
@@ -191,7 +191,7 @@ class Zones(resource.BaseResource):
     def export(self, zone, callback=None, errback=None):
         """
         Export zone as BIND-compatible zone file.
-        
+
         :param str zone: zone name
         :return: zone file content as string
         """

--- a/ns1/zones.py
+++ b/ns1/zones.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014 NSONE, Inc.
+# Copyright IBM Corp. 2014, 2026
 #
 # License under The MIT License (MIT). See LICENSE in project root.
 #

--- a/ns1/zones.py
+++ b/ns1/zones.py
@@ -61,7 +61,9 @@ class Zone(object):
             else:
                 return self
 
-        return self._rest.retrieve(self.zone, callback=success, errback=errback)
+        return self._rest.retrieve(
+            self.zone, callback=success, errback=errback
+        )
 
     def delete(self, callback=None, errback=None):
         """
@@ -86,9 +88,13 @@ class Zone(object):
             else:
                 return self
 
-        return self._rest.update(self.zone, callback=success, errback=errback, **kwargs)
+        return self._rest.update(
+            self.zone, callback=success, errback=errback, **kwargs
+        )
 
-    def create(self, zoneFile=None, callback=None, errback=None, name=None, **kwargs):
+    def create(
+        self, zoneFile=None, callback=None, errback=None, name=None, **kwargs
+    ):
         """
         Create a new zone. Pass a list of keywords and their values to
         configure. For the list of keywords available for zone configuration,
@@ -144,7 +150,9 @@ class Zone(object):
 
         return add_X
 
-    def createLinkToSelf(self, new_zone, callback=None, errback=None, **kwargs):
+    def createLinkToSelf(
+        self, new_zone, callback=None, errback=None, **kwargs
+    ):
         """
         Create a new linked zone, linking to ourselves. All records in this
         zone will then be available as "linked records" in the new zone.
@@ -278,9 +286,13 @@ class Zone(object):
         :return: usage information
         """
         stats = Stats(self.config)
-        return stats.usage(zone=self.zone, callback=callback, errback=errback, **kwargs)
+        return stats.usage(
+            zone=self.zone, callback=callback, errback=errback, **kwargs
+        )
 
-    def export(self, callback=None, errback=None, timeout=300, poll_interval=2):
+    def export(
+        self, callback=None, errback=None, timeout=300, poll_interval=2
+    ):
         """
         Export zone as a BIND-compatible zone file.
 
@@ -297,14 +309,18 @@ class Zone(object):
         # Initiate the export
         init_response = self._rest.initiate_zonefile_export(self.zone)
         if not init_response or init_response.get("status") == "FAILED":
-            error_msg = init_response.get("message", "Failed to initiate export")
+            error_msg = init_response.get(
+                "message", "Failed to initiate export"
+            )
             raise ZoneException(f"Zone export initiation failed: {error_msg}")
 
         # Poll the status until complete or failed
         start_time = time.time()
         while True:
             if time.time() - start_time > timeout:
-                raise ZoneException(f"Zone export timed out after {timeout} seconds")
+                raise ZoneException(
+                    f"Zone export timed out after {timeout} seconds"
+                )
 
             status_response = self._rest.status_zonefile_export(self.zone)
             status = status_response.get("status")

--- a/ns1/zones.py
+++ b/ns1/zones.py
@@ -61,9 +61,7 @@ class Zone(object):
             else:
                 return self
 
-        return self._rest.retrieve(
-            self.zone, callback=success, errback=errback
-        )
+        return self._rest.retrieve(self.zone, callback=success, errback=errback)
 
     def delete(self, callback=None, errback=None):
         """
@@ -88,13 +86,9 @@ class Zone(object):
             else:
                 return self
 
-        return self._rest.update(
-            self.zone, callback=success, errback=errback, **kwargs
-        )
+        return self._rest.update(self.zone, callback=success, errback=errback, **kwargs)
 
-    def create(
-        self, zoneFile=None, callback=None, errback=None, name=None, **kwargs
-    ):
+    def create(self, zoneFile=None, callback=None, errback=None, name=None, **kwargs):
         """
         Create a new zone. Pass a list of keywords and their values to
         configure. For the list of keywords available for zone configuration,
@@ -150,9 +144,7 @@ class Zone(object):
 
         return add_X
 
-    def createLinkToSelf(
-        self, new_zone, callback=None, errback=None, **kwargs
-    ):
+    def createLinkToSelf(self, new_zone, callback=None, errback=None, **kwargs):
         """
         Create a new linked zone, linking to ourselves. All records in this
         zone will then be available as "linked records" in the new zone.
@@ -286,13 +278,9 @@ class Zone(object):
         :return: usage information
         """
         stats = Stats(self.config)
-        return stats.usage(
-            zone=self.zone, callback=callback, errback=errback, **kwargs
-        )
+        return stats.usage(zone=self.zone, callback=callback, errback=errback, **kwargs)
 
-    def export(
-        self, callback=None, errback=None, timeout=300, poll_interval=2
-    ):
+    def export(self, callback=None, errback=None, timeout=300, poll_interval=2):
         """
         Export zone as a BIND-compatible zone file.
 
@@ -309,18 +297,14 @@ class Zone(object):
         # Initiate the export
         init_response = self._rest.initiate_zonefile_export(self.zone)
         if not init_response or init_response.get("status") == "FAILED":
-            error_msg = init_response.get(
-                "message", "Failed to initiate export"
-            )
+            error_msg = init_response.get("message", "Failed to initiate export")
             raise ZoneException(f"Zone export initiation failed: {error_msg}")
 
         # Poll the status until complete or failed
         start_time = time.time()
         while True:
             if time.time() - start_time > timeout:
-                raise ZoneException(
-                    f"Zone export timed out after {timeout} seconds"
-                )
+                raise ZoneException(f"Zone export timed out after {timeout} seconds")
 
             status_response = self._rest.status_zonefile_export(self.zone)
             status = status_response.get("status")

--- a/ns1/zones.py
+++ b/ns1/zones.py
@@ -291,7 +291,7 @@ class Zone(object):
     def export(self, callback=None, errback=None):
         """
         Export zone as a BIND-compatible zone file.
-        
+
         :param callback: optional callback
         :param errback: optional error callback
         :return: zone file content as string

--- a/ns1/zones.py
+++ b/ns1/zones.py
@@ -287,3 +287,15 @@ class Zone(object):
         return stats.usage(
             zone=self.zone, callback=callback, errback=errback, **kwargs
         )
+
+    def export(self, callback=None, errback=None):
+        """
+        Export zone as a BIND-compatible zone file.
+        
+        :param callback: optional callback
+        :param errback: optional error callback
+        :return: zone file content as string
+        """
+        return self._rest.export(
+            self.zone, callback=callback, errback=errback
+        )

--- a/ns1/zones.py
+++ b/ns1/zones.py
@@ -297,3 +297,27 @@ class Zone(object):
         :return: zone file content as string
         """
         return self._rest.export(self.zone, callback=callback, errback=errback)
+
+    def initiate_export(self, callback=None, errback=None):
+        """
+        Initiate zone export job.
+
+        :param callback: optional callback
+        :param errback: optional error callback
+        :return: export status response
+        """
+        return self._rest.initiate_export(
+            self.zone, callback=callback, errback=errback
+        )
+
+    def export_status(self, callback=None, errback=None):
+        """
+        Check zone export status.
+
+        :param callback: optional callback
+        :param errback: optional error callback
+        :return: export status response
+        """
+        return self._rest.export_status(
+            self.zone, callback=callback, errback=errback
+        )

--- a/ns1/zones.py
+++ b/ns1/zones.py
@@ -123,7 +123,7 @@ class Zone(object):
                 callback=success,
                 errback=errback,
                 name=name,
-                **kwargs
+                **kwargs,
             )
         else:
             return self._rest.create(
@@ -131,7 +131,7 @@ class Zone(object):
                 callback=success,
                 errback=errback,
                 name=name,
-                **kwargs
+                **kwargs,
             )
 
     def __getattr__(self, item):
@@ -169,7 +169,7 @@ class Zone(object):
         rtype,
         callback=None,
         errback=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Create a new linked record in this zone. These records use the
@@ -194,7 +194,7 @@ class Zone(object):
             link=existing_domain,
             callback=callback,
             errback=errback,
-            **kwargs
+            **kwargs,
         )
 
     def cloneRecord(
@@ -288,10 +288,12 @@ class Zone(object):
             zone=self.zone, callback=callback, errback=errback, **kwargs
         )
 
-    def export(self, callback=None, errback=None, timeout=300, poll_interval=2):
+    def export(
+        self, callback=None, errback=None, timeout=300, poll_interval=2
+    ):
         """
         Export zone as a BIND-compatible zone file.
-        
+
         This method initiates the export, polls the status until complete or failed,
         and downloads the zone file.
 
@@ -330,7 +332,7 @@ class Zone(object):
         zone_file = self._rest.get_zonefile_export(
             self.zone, callback=callback, errback=errback
         )
-        
+
         if callback:
             return callback(zone_file)
         return zone_file

--- a/ns1/zones.py
+++ b/ns1/zones.py
@@ -296,6 +296,4 @@ class Zone(object):
         :param errback: optional error callback
         :return: zone file content as string
         """
-        return self._rest.export(
-            self.zone, callback=callback, errback=errback
-        )
+        return self._rest.export(self.zone, callback=callback, errback=errback)

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -256,10 +256,10 @@ def test_rest_zone_buildbody(zones_config):
 @pytest.mark.parametrize(
     "zone, url", [("test.zone", "zones/test.zone/export")]
 )
-def test_rest_zone_export(zones_config, zone, url):
+def test_rest_zone_get_zonefile_export(zones_config, zone, url):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()
-    z.export(zone)
+    z.get_zonefile_export(zone)
     z._make_request.assert_called_once_with(
         "GET",
         url,
@@ -271,10 +271,10 @@ def test_rest_zone_export(zones_config, zone, url):
 @pytest.mark.parametrize(
     "zone, url", [("test.zone", "export/zonefile/test.zone")]
 )
-def test_rest_zone_initiate_export(zones_config, zone, url):
+def test_rest_zone_initiate_zonefile_export(zones_config, zone, url):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()
-    z.initiate_export(zone)
+    z.initiate_zonefile_export(zone)
     z._make_request.assert_called_once_with(
         "PUT",
         url,
@@ -287,10 +287,10 @@ def test_rest_zone_initiate_export(zones_config, zone, url):
 @pytest.mark.parametrize(
     "zone, url", [("test.zone", "export/zonefile/test.zone/status")]
 )
-def test_rest_zone_export_status(zones_config, zone, url):
+def test_rest_zone_status_zonefile_export(zones_config, zone, url):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()
-    z.export_status(zone)
+    z.status_zonefile_export(zone)
     z._make_request.assert_called_once_with(
         "GET",
         url,

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -253,7 +253,9 @@ def test_rest_zone_buildbody(zones_config):
     assert z._buildBody(zone, **kwargs) == body
 
 
-@pytest.mark.parametrize("zone, url", [("test.zone", "zones/test.zone/export")])
+@pytest.mark.parametrize(
+    "zone, url", [("test.zone", "zones/test.zone/export")]
+)
 def test_rest_zone_export(zones_config, zone, url):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -1,3 +1,9 @@
+#
+# Copyright IBM Corp. 2014, 2026
+#
+# License under The MIT License (MIT). See LICENSE in project root.
+#
+
 import ns1.rest.zones
 import pytest
 import os

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -251,3 +251,17 @@ def test_rest_zone_buildbody(zones_config):
         "tags": {"foo": "bar", "hai": "bai"},
     }
     assert z._buildBody(zone, **kwargs) == body
+
+
+
+@pytest.mark.parametrize("zone, url", [("test.zone", "zones/test.zone/export")])
+def test_rest_zone_export(zones_config, zone, url):
+    z = ns1.rest.zones.Zones(zones_config)
+    z._make_request = mock.MagicMock()
+    z.export(zone)
+    z._make_request.assert_called_once_with(
+        "GET",
+        url,
+        callback=None,
+        errback=None,
+    )

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -53,9 +53,7 @@ def test_rest_zone_retrieve(zones_config, zone, url):
     )
 
 
-@pytest.mark.parametrize(
-    "zone, url", [("test.zone", "zones/test.zone/versions")]
-)
+@pytest.mark.parametrize("zone, url", [("test.zone", "zones/test.zone/versions")])
 def test_rest_zone_version_list(zones_config, zone, url):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()
@@ -253,9 +251,7 @@ def test_rest_zone_buildbody(zones_config):
     assert z._buildBody(zone, **kwargs) == body
 
 
-@pytest.mark.parametrize(
-    "zone, url", [("test.zone", "export/zonefile/test.zone")]
-)
+@pytest.mark.parametrize("zone, url", [("test.zone", "export/zonefile/test.zone")])
 def test_rest_zone_get_zonefile_export(zones_config, zone, url):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()
@@ -268,9 +264,7 @@ def test_rest_zone_get_zonefile_export(zones_config, zone, url):
     )
 
 
-@pytest.mark.parametrize(
-    "zone, url", [("test.zone", "export/zonefile/test.zone")]
-)
+@pytest.mark.parametrize("zone, url", [("test.zone", "export/zonefile/test.zone")])
 def test_rest_zone_initiate_zonefile_export(zones_config, zone, url):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -254,7 +254,7 @@ def test_rest_zone_buildbody(zones_config):
 
 
 @pytest.mark.parametrize(
-    "zone, url", [("test.zone", "zones/test.zone/export")]
+    "zone, url", [("test.zone", "export/zonefile/test.zone")]
 )
 def test_rest_zone_get_zonefile_export(zones_config, zone, url):
     z = ns1.rest.zones.Zones(zones_config)

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -253,7 +253,6 @@ def test_rest_zone_buildbody(zones_config):
     assert z._buildBody(zone, **kwargs) == body
 
 
-
 @pytest.mark.parametrize("zone, url", [("test.zone", "zones/test.zone/export")])
 def test_rest_zone_export(zones_config, zone, url):
     z = ns1.rest.zones.Zones(zones_config)

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -271,6 +271,7 @@ def test_rest_zone_get_zonefile_export(zones_config, zone, url):
         url,
         callback=None,
         errback=None,
+        skip_json_parsing=True,
     )
 
 

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -266,3 +266,34 @@ def test_rest_zone_export(zones_config, zone, url):
         callback=None,
         errback=None,
     )
+
+
+@pytest.mark.parametrize(
+    "zone, url", [("test.zone", "export/zonefile/test.zone")]
+)
+def test_rest_zone_initiate_export(zones_config, zone, url):
+    z = ns1.rest.zones.Zones(zones_config)
+    z._make_request = mock.MagicMock()
+    z.initiate_export(zone)
+    z._make_request.assert_called_once_with(
+        "PUT",
+        url,
+        body={},
+        callback=None,
+        errback=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "zone, url", [("test.zone", "export/zonefile/test.zone/status")]
+)
+def test_rest_zone_export_status(zones_config, zone, url):
+    z = ns1.rest.zones.Zones(zones_config)
+    z._make_request = mock.MagicMock()
+    z.export_status(zone)
+    z._make_request.assert_called_once_with(
+        "GET",
+        url,
+        callback=None,
+        errback=None,
+    )

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -53,7 +53,9 @@ def test_rest_zone_retrieve(zones_config, zone, url):
     )
 
 
-@pytest.mark.parametrize("zone, url", [("test.zone", "zones/test.zone/versions")])
+@pytest.mark.parametrize(
+    "zone, url", [("test.zone", "zones/test.zone/versions")]
+)
 def test_rest_zone_version_list(zones_config, zone, url):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()
@@ -251,7 +253,9 @@ def test_rest_zone_buildbody(zones_config):
     assert z._buildBody(zone, **kwargs) == body
 
 
-@pytest.mark.parametrize("zone, url", [("test.zone", "export/zonefile/test.zone")])
+@pytest.mark.parametrize(
+    "zone, url", [("test.zone", "export/zonefile/test.zone")]
+)
 def test_rest_zone_get_zonefile_export(zones_config, zone, url):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()
@@ -264,7 +268,9 @@ def test_rest_zone_get_zonefile_export(zones_config, zone, url):
     )
 
 
-@pytest.mark.parametrize("zone, url", [("test.zone", "export/zonefile/test.zone")])
+@pytest.mark.parametrize(
+    "zone, url", [("test.zone", "export/zonefile/test.zone")]
+)
 def test_rest_zone_initiate_zonefile_export(zones_config, zone, url):
     z = ns1.rest.zones.Zones(zones_config)
     z._make_request = mock.MagicMock()


### PR DESCRIPTION
- Add export() method to REST API and Zone class
- Add unit test for zone export
- Add simple usage example

Allows customers to export zones in BIND format for backup/migration.