### PR TITLE
PENG-7932 - Python SDK Updates for API Key expiry and renewal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.28.0 (May Nth, 2026)
+## 0.28.0 (June 8th, 2026)
 
 ENHANCEMENTS:
 * Add support for API Key expiry and secret renewal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.28.0 (May Nth, 2026)
+
+ENHANCEMENTS:
+* Add support for API Key expiry and secret renewal
+
 ## 0.27.4 (May 14th, 2026)
 
 BUG FIXES:

--- a/examples/apikey-secret-renewal.py
+++ b/examples/apikey-secret-renewal.py
@@ -6,11 +6,13 @@
 
 from ns1 import NS1
 
+
 def print_secret(secret):
     print(f"  Secret ID: {secret['secret_id']}")
     print(f"  Secret Value: {secret['secret']}")
     print(f"  Expires At: {secret['expires_at']}")
     print(f"  Enabled: {secret['enabled']}")
+
 
 # NS1 will use config in ~/.nsone by default
 api = NS1()
@@ -44,7 +46,7 @@ try:
     # Store the actual apikey for later operations
     apikey_id = apikey["id"]
     apikey_secret = apikey["secrets"][0]
-    apikey_secret_id= apikey_secret["secret_id"]
+    apikey_secret_is = apikey_secret["secret_id"]
     apikey_secret_key = apikey_secret["secret"]
 
     print("Initial api key secret:")
@@ -61,7 +63,7 @@ try:
     # The default secret id for renew() is "self" and this will
     # renew the secret being used for authentication.
     new_secret = apikeysecrets_with_secret_auth.renew()
-    print(f"Renewed api key secret:")
+    print("Renewed api key secret:")
     print_secret(new_secret)
 finally:
     # Clean up the API key so this script can be re-run

--- a/examples/apikey-secret-renewal.py
+++ b/examples/apikey-secret-renewal.py
@@ -1,0 +1,69 @@
+#
+# Copyright (c) 2026 NSONE, Inc.
+#
+# License under The MIT License (MIT). See LICENSE in project root.
+#
+
+from ns1 import NS1
+
+def print_secret(secret):
+    print(f"  Secret ID: {secret['secret_id']}")
+    print(f"  Secret Value: {secret['secret']}")
+    print(f"  Expires At: {secret['expires_at']}")
+    print(f"  Enabled: {secret['enabled']}")
+
+# NS1 will use config in ~/.nsone by default
+api = NS1()
+
+# to specify an apikey here instead, use:
+# api = NS1(apiKey='<<CLEARTEXT API KEY>>')
+
+# to load an alternate configuration file:
+# api = NS1(configFile='/etc/ns1/api.json')
+
+########################
+# CREATE API KEY       #
+########################
+
+# Get the API key interface
+apikey_api = api.apikey()
+
+# Create a new API key with a name and expiry_duration
+# You can also specify teams, ip_whitelist, ip_whitelist_strict, and permissions
+# If permissions are not specified, default permissions (all false) will be used
+# expiry_duration is set to 30 days
+apikey_id = ''
+try:
+    print('Creating API key with 30 day expiry...')
+    apikey = apikey_api.create("example-api-key-with-expiry", expiry_duration="30d")
+    apikey_id = apikey["id"]
+    print(f"Created API key: {apikey_id}")
+
+    # Store the key ID for later operations
+
+    # Store the actual apikey for later operations
+    apikey_id = apikey["id"]
+    apikey_secret = apikey["secrets"][0]
+    apikey_secret_id= apikey_secret["secret_id"]
+    apikey_secret_key = apikey_secret["secret"]
+
+    print("Initial api key secret:")
+    print_secret(apikey_secret)
+
+    ########################
+    # RENEW API KEY        #
+    ########################
+
+    # Use self renewal to renew this secret by creating a new api
+    # instance that uses the new secret for authentication.
+    api_with_secret_auth = NS1(apiKey=apikey_secret_key)
+    apikeysecrets_with_secret_auth = api_with_secret_auth.apikeysecrets()
+    # The default secret id for renew() is "self" and this will
+    # renew the secret being used for authentication.
+    new_secret = apikeysecrets_with_secret_auth.renew()
+    print(f"Renewed api key secret:")
+    print_secret(new_secret)
+finally:
+    # Clean up the API key so this script can be re-run
+    if apikey_id != '':
+        apikey_api.delete(apikey_id)

--- a/examples/apikey-secret-renewal.py
+++ b/examples/apikey-secret-renewal.py
@@ -23,10 +23,6 @@ api = NS1()
 # to load an alternate configuration file:
 # api = NS1(configFile='/etc/ns1/api.json')
 
-########################
-# CREATE API KEY       #
-########################
-
 # Get the API key interface
 apikey_api = api.apikey()
 
@@ -36,6 +32,9 @@ apikey_api = api.apikey()
 # expiry_duration is set to 30 days
 apikey_id = ""
 try:
+    ###########################
+    # CREATE EXPIRING API KEY #
+    ###########################
     print("Creating API key with 30 day expiry...")
     apikey = apikey_api.create(
         "example-api-key-with-expiry", expiry_duration="30d"

--- a/examples/apikey-secret-renewal.py
+++ b/examples/apikey-secret-renewal.py
@@ -34,10 +34,12 @@ apikey_api = api.apikey()
 # You can also specify teams, ip_whitelist, ip_whitelist_strict, and permissions
 # If permissions are not specified, default permissions (all false) will be used
 # expiry_duration is set to 30 days
-apikey_id = ''
+apikey_id = ""
 try:
-    print('Creating API key with 30 day expiry...')
-    apikey = apikey_api.create("example-api-key-with-expiry", expiry_duration="30d")
+    print("Creating API key with 30 day expiry...")
+    apikey = apikey_api.create(
+        "example-api-key-with-expiry", expiry_duration="30d"
+    )
     apikey_id = apikey["id"]
     print(f"Created API key: {apikey_id}")
 
@@ -67,5 +69,5 @@ try:
     print_secret(new_secret)
 finally:
     # Clean up the API key so this script can be re-run
-    if apikey_id != '':
+    if apikey_id != "":
         apikey_api.delete(apikey_id)

--- a/ns1/__init__.py
+++ b/ns1/__init__.py
@@ -5,7 +5,7 @@
 #
 from .config import Config
 
-version = "0.27.4"
+version = "0.28.0"
 
 
 class NS1:
@@ -182,6 +182,16 @@ class NS1:
         import ns1.rest.apikey
 
         return ns1.rest.apikey.APIKey(self.config)
+
+    def apikeysecrets(self):
+        """
+        Return a new raw REST interface to API key secret resources
+
+        :rtype: :py:class:`ns1.rest.apikey_secret.APIKeySecret`
+        """
+        import ns1.rest.apikey_secret
+
+        return ns1.rest.apikey_secret.APIKeySecret(self.config)
 
     def acls(self):
         """

--- a/ns1/rest/apikey.py
+++ b/ns1/rest/apikey.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014 NSONE, Inc.
+# Copyright (c) 2014, 2026 NSONE, Inc.
 #
 # License under The MIT License (MIT). See LICENSE in project root.
 #
@@ -15,6 +15,7 @@ class APIKey(resource.BaseResource):
         "ip_whitelist",
         "ip_whitelist_strict",
         "permissions",
+        "expiry_duration",
     ]
 
     def create(self, name, callback=None, errback=None, **kwargs):

--- a/ns1/rest/apikey_secret.py
+++ b/ns1/rest/apikey_secret.py
@@ -17,43 +17,6 @@ class APIKeySecret(resource.BaseResource):
         "enabled",
     ]
 
-    # Forward HTTP methods needed by APIKey Secrets API
-    def _get(self, path, params=None):
-        """Forward GET requests to make_request"""
-        # Fix path to start with /apikeys/v1/secrets/ if needed
-        if path.startswith("/"):
-            path = path[1:]  # Remove leading slash
-        if not path.startswith("apikeys/v1/secrets/"):
-            # Secret endpoints should have this prefix
-            path = f"{self.ROOT}/{path.split('/')[-1]}"
-        return self._make_request("GET", path, params=params)
-
-    def _post(self, path, json=None):
-        """Forward POST requests to make_request"""
-        if path.startswith("/"):
-            path = path[1:]  # Remove leading slash
-        if not path.startswith("apikeys/v1/secrets/"):
-            path = f"{self.ROOT}"
-        return self._make_request("POST", path, body=json)
-
-    def _patch(self, path, json=None):
-        """Forward PATCH requests to make_request"""
-        if path.startswith("/"):
-            path = path[1:]  # Remove leading slash
-        if not path.startswith("apikeys/v1/secrets/"):
-            parts = path.split("/")
-            path = f"{self.ROOT}/{parts[-1]}"
-        return self._make_request("PATCH", path, body=json)
-
-    def _delete(self, path):
-        """Forward DELETE requests to make_request"""
-        if path.startswith("/"):
-            path = path[1:]  # Remove leading slash
-        if not path.startswith("apikeys/v1/secrets/"):
-            parts = path.split("/")
-            path = f"{self.ROOT}/{parts[-1]}"
-        return self._make_request("DELETE", path)
-
     def update(self, secret_id, callback=None, errback=None, **kwargs):
         body = {}
         self._buildStdBody(body, kwargs)

--- a/ns1/rest/apikey_secret.py
+++ b/ns1/rest/apikey_secret.py
@@ -13,7 +13,7 @@ class APIKeySecret(resource.BaseResource):
         "expires_at",
     ]
 
-    BOOL_FIELDS= [
+    BOOL_FIELDS = [
         "enabled",
     ]
 

--- a/ns1/rest/apikey_secret.py
+++ b/ns1/rest/apikey_secret.py
@@ -1,0 +1,91 @@
+#
+# Copyright (c) 2026 NSONE, Inc.
+#
+# License under The MIT License (MIT). See LICENSE in project root.
+#
+from . import resource
+
+
+class APIKeySecret(resource.BaseResource):
+    ROOT = "../apikeys/v1/secrets"
+
+    PASSTHRU_FIELDS = [
+        "expires_at",
+    ]
+
+    BOOL_FIELDS= [
+        "enabled",
+    ]
+
+    # Forward HTTP methods needed by APIKey Secrets API
+    def _get(self, path, params=None):
+        """Forward GET requests to make_request"""
+        # Fix path to start with /apikeys/v1/secrets/ if needed
+        if path.startswith("/"):
+            path = path[1:]  # Remove leading slash
+        if not path.startswith("apikeys/v1/secrets/"):
+            # Secret endpoints should have this prefix
+            path = f"{self.ROOT}/{path.split('/')[-1]}"
+        return self._make_request("GET", path, params=params)
+
+    def _post(self, path, json=None):
+        """Forward POST requests to make_request"""
+        if path.startswith("/"):
+            path = path[1:]  # Remove leading slash
+        if not path.startswith("apikeys/v1/secrets/"):
+            path = f"{self.ROOT}"
+        return self._make_request("POST", path, body=json)
+
+    def _patch(self, path, json=None):
+        """Forward PATCH requests to make_request"""
+        if path.startswith("/"):
+            path = path[1:]  # Remove leading slash
+        if not path.startswith("apikeys/v1/secrets/"):
+            parts = path.split("/")
+            path = f"{self.ROOT}/{parts[-1]}"
+        return self._make_request("PATCH", path, body=json)
+
+    def _delete(self, path):
+        """Forward DELETE requests to make_request"""
+        if path.startswith("/"):
+            path = path[1:]  # Remove leading slash
+        if not path.startswith("apikeys/v1/secrets/"):
+            parts = path.split("/")
+            path = f"{self.ROOT}/{parts[-1]}"
+        return self._make_request("DELETE", path)
+
+    def update(self, secret_id, callback=None, errback=None, **kwargs):
+        body = {}
+        self._buildStdBody(body, kwargs)
+
+        return self._make_request(
+            "PUT",
+            "%s/%s" % (self.ROOT, secret_id),
+            body=body,
+            callback=callback,
+            errback=errback,
+        )
+
+    def retrieve(self, secret_id="self", callback=None, errback=None):
+        return self._make_request(
+            "GET",
+            "%s/%s" % (self.ROOT, secret_id),
+            callback=callback,
+            errback=errback,
+        )
+
+    def renew(self, secret_id="self", callback=None, errback=None):
+        return self._make_request(
+            "POST",
+            "%s/%s/renew" % (self.ROOT, secret_id),
+            callback=callback,
+            errback=errback,
+        )
+
+    def delete(self, secret_id, callback=None, errback=None):
+        return self._make_request(
+            "DELETE",
+            "%s/%s" % (self.ROOT, secret_id),
+            callback=callback,
+            errback=errback,
+        )

--- a/ns1/rest/transport/twisted.py
+++ b/ns1/rest/transport/twisted.py
@@ -82,6 +82,7 @@ class StringProducer(object):
 
 
 if have_twisted:
+
     @implementer(IPolicyForHTTPS)
     class NoValidationPolicy(object):
         def creatorForNetloc(self, hostname, port):

--- a/tests/unit/test_apikey.py
+++ b/tests/unit/test_apikey.py
@@ -58,11 +58,12 @@ def test_rest_apikey_create(apikey_config, name, url):
         body={"name": name, "permissions": permissions._default_perms},
     )
 
+
 @pytest.mark.parametrize("name, url", [("test-apikey-with-expiry", "account/apikeys")])
 def test_rest_apikey_create_with_expiry(apikey_config, name, url):
     z = ns1.rest.apikey.APIKey(apikey_config)
     z._make_request = mock.MagicMock()
-    z.create(name, expiry_duration = "10d")
+    z.create(name, expiry_duration="10d")
     z._make_request.assert_called_once_with(
         "PUT",
         url,
@@ -70,6 +71,7 @@ def test_rest_apikey_create_with_expiry(apikey_config, name, url):
         errback=None,
         body={"name": name, "permissions": permissions._default_perms, "expiry_duration": "10d"},
     )
+
 
 @pytest.mark.parametrize(
     "apikey_id, name, ip_whitelist, permissions, url",

--- a/tests/unit/test_apikey.py
+++ b/tests/unit/test_apikey.py
@@ -58,6 +58,18 @@ def test_rest_apikey_create(apikey_config, name, url):
         body={"name": name, "permissions": permissions._default_perms},
     )
 
+@pytest.mark.parametrize("name, url", [("test-apikey-with-expiry", "account/apikeys")])
+def test_rest_apikey_create_with_expiry(apikey_config, name, url):
+    z = ns1.rest.apikey.APIKey(apikey_config)
+    z._make_request = mock.MagicMock()
+    z.create(name, expiry_duration = "10d")
+    z._make_request.assert_called_once_with(
+        "PUT",
+        url,
+        callback=None,
+        errback=None,
+        body={"name": name, "permissions": permissions._default_perms, "expiry_duration": "10d"},
+    )
 
 @pytest.mark.parametrize(
     "apikey_id, name, ip_whitelist, permissions, url",

--- a/tests/unit/test_apikey.py
+++ b/tests/unit/test_apikey.py
@@ -59,7 +59,9 @@ def test_rest_apikey_create(apikey_config, name, url):
     )
 
 
-@pytest.mark.parametrize("name, url", [("test-apikey-with-expiry", "account/apikeys")])
+@pytest.mark.parametrize(
+    "name, url", [("test-apikey-with-expiry", "account/apikeys")]
+)
 def test_rest_apikey_create_with_expiry(apikey_config, name, url):
     z = ns1.rest.apikey.APIKey(apikey_config)
     z._make_request = mock.MagicMock()
@@ -69,7 +71,11 @@ def test_rest_apikey_create_with_expiry(apikey_config, name, url):
         url,
         callback=None,
         errback=None,
-        body={"name": name, "permissions": permissions._default_perms, "expiry_duration": "10d"},
+        body={
+            "name": name,
+            "permissions": permissions._default_perms,
+            "expiry_duration": "10d",
+        },
     )
 
 

--- a/tests/unit/test_apikey_secrets.py
+++ b/tests/unit/test_apikey_secrets.py
@@ -88,6 +88,7 @@ def test_rest_apikey_secret_delete(apikey_secret_config, secret_id, url):
         "DELETE", url, callback=None, errback=None
     )
 
+
 @pytest.mark.parametrize(
     "secret_id, url",
     [
@@ -103,6 +104,7 @@ def test_rest_apikey_secret_retrieve(apikey_secret_config, secret_id, url):
         "GET", url, callback=None, errback=None
     )
 
+
 @pytest.mark.parametrize(
     "url",
     [
@@ -116,6 +118,7 @@ def test_rest_apikey_secret_retrieve_self(apikey_secret_config, url):
     z._make_request.assert_called_once_with(
         "GET", url, callback=None, errback=None
     )
+
 
 @pytest.mark.parametrize(
     "secret_id, url",
@@ -131,6 +134,7 @@ def test_rest_apikey_secret_renew(apikey_secret_config, secret_id, url):
     z._make_request.assert_called_once_with(
         "POST", url, callback=None, errback=None
     )
+
 
 @pytest.mark.parametrize(
     "url",

--- a/tests/unit/test_apikey_secrets.py
+++ b/tests/unit/test_apikey_secrets.py
@@ -1,0 +1,147 @@
+#
+# Copyright (c) 2026 NSONE, Inc.
+#
+# License under The MIT License (MIT). See LICENSE in project root.
+#
+import ns1.rest.apikey_secret
+import pytest
+
+try:  # Python 3.3 +
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+
+@pytest.fixture
+def apikey_secret_config(config):
+    config.loadFromDict(
+        {
+            "endpoint": "api.nsone.net",
+            "default_key": "test1",
+            "keys": {
+                "test1": {
+                    "key": "key-1",
+                    "desc": "test key number 1",
+                }
+            },
+        }
+    )
+
+    return config
+
+
+@pytest.mark.parametrize(
+    "secret_id, enabled, expires_at, url",
+    [
+        (
+            "secret-123",
+            True,
+            1234567890,
+            "../apikeys/v1/secrets/secret-123",
+        ),
+        (
+            "secret-456",
+            False,
+            None,
+            "../apikeys/v1/secrets/secret-456",
+        ),
+    ],
+)
+def test_rest_apikey_secret_update(
+    apikey_secret_config, secret_id, enabled, expires_at, url
+):
+    z = ns1.rest.apikey_secret.APIKeySecret(apikey_secret_config)
+    z._make_request = mock.MagicMock()
+
+    if expires_at:
+        z.update(secret_id, enabled=enabled, expires_at=expires_at)
+        z._make_request.assert_called_once_with(
+            "PUT",
+            url,
+            callback=None,
+            errback=None,
+            body={"enabled": enabled, "expires_at": expires_at},
+        )
+    else:
+        z.update(secret_id, enabled=enabled)
+        z._make_request.assert_called_once_with(
+            "PUT",
+            url,
+            callback=None,
+            errback=None,
+            body={"enabled": enabled},
+        )
+
+
+@pytest.mark.parametrize(
+    "secret_id, url",
+    [
+        ("secret-123", "../apikeys/v1/secrets/secret-123"),
+        ("secret-abc", "../apikeys/v1/secrets/secret-abc"),
+    ],
+)
+def test_rest_apikey_secret_delete(apikey_secret_config, secret_id, url):
+    z = ns1.rest.apikey_secret.APIKeySecret(apikey_secret_config)
+    z._make_request = mock.MagicMock()
+    z.delete(secret_id)
+    z._make_request.assert_called_once_with(
+        "DELETE", url, callback=None, errback=None
+    )
+
+@pytest.mark.parametrize(
+    "secret_id, url",
+    [
+        ("secret-123", "../apikeys/v1/secrets/secret-123"),
+        ("secret-abc", "../apikeys/v1/secrets/secret-abc"),
+    ],
+)
+def test_rest_apikey_secret_retrieve(apikey_secret_config, secret_id, url):
+    z = ns1.rest.apikey_secret.APIKeySecret(apikey_secret_config)
+    z._make_request = mock.MagicMock()
+    z.retrieve(secret_id)
+    z._make_request.assert_called_once_with(
+        "GET", url, callback=None, errback=None
+    )
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        ("../apikeys/v1/secrets/self"),
+    ],
+)
+def test_rest_apikey_secret_retrieve_self(apikey_secret_config, url):
+    z = ns1.rest.apikey_secret.APIKeySecret(apikey_secret_config)
+    z._make_request = mock.MagicMock()
+    z.retrieve()
+    z._make_request.assert_called_once_with(
+        "GET", url, callback=None, errback=None
+    )
+
+@pytest.mark.parametrize(
+    "secret_id, url",
+    [
+        ("secret-123", "../apikeys/v1/secrets/secret-123/renew"),
+        ("secret-abc", "../apikeys/v1/secrets/secret-abc/renew"),
+    ],
+)
+def test_rest_apikey_secret_renew(apikey_secret_config, secret_id, url):
+    z = ns1.rest.apikey_secret.APIKeySecret(apikey_secret_config)
+    z._make_request = mock.MagicMock()
+    z.renew(secret_id)
+    z._make_request.assert_called_once_with(
+        "POST", url, callback=None, errback=None
+    )
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        ("../apikeys/v1/secrets/self/renew"),
+    ],
+)
+def test_rest_apikey_secret_renew_self(apikey_secret_config, url):
+    z = ns1.rest.apikey_secret.APIKeySecret(apikey_secret_config)
+    z._make_request = mock.MagicMock()
+    z.renew()
+    z._make_request.assert_called_once_with(
+        "POST", url, callback=None, errback=None
+    )


### PR DESCRIPTION
- Add support for creating expiring API Keys.
- Add support for managing and renewing expiring API Key secrets.
- Add example code for API Key renewal.
- Add testcases.
- Increment minor version number and update changelog.

NOTE: RELEASE DATE MUST BE UPDATED BEFORE MERGING